### PR TITLE
fix: make tmux-run pane targeting index-agnostic

### DIFF
--- a/references/WORKFLOW.md
+++ b/references/WORKFLOW.md
@@ -159,7 +159,7 @@ For automated, durable runs where a TTY is required and logs must be preserved.
 **Workflow:**
 1. **Start**: `./scripts/tmux-run timeout 300s codex --yolo exec "Implement X..."`
 2. **Monitor**: `tmux -S "$SOCKET" attach -t "<session>"`
-3. **Capture**: `tmux -S "$SOCKET" capture-pane -p -J -t "<session>":0.0 -S -200`
+3. **Capture**: `tmux -S "$SOCKET" capture-pane -p -J -t "<session>:<window>.<pane>" -S -200`
 4. **Cleanup**: `tmux -S "$SOCKET" kill-session -t "<session>"`
 
 **Note:** This skill disables MCP usage. All automation is via tmux + CLI.

--- a/references/quick-reference.md
+++ b/references/quick-reference.md
@@ -141,11 +141,12 @@ SOCKET="$SOCKET_DIR/openclaw.sock"
 SESSION=codex-review
 
 tmux -S "$SOCKET" new-session -d -s "$SESSION" -n shell
-tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 -l -- "codex review --base main" Enter
+TARGET="$(tmux -S "$SOCKET" list-panes -t "$SESSION" -F "#{session_name}:#{window_index}.#{pane_index}" | head -n 1)"
+tmux -S "$SOCKET" send-keys -t "$TARGET" -l -- "codex review --base main" Enter
 
 # Monitor
 tmux -S "$SOCKET" attach -t "$SESSION"
-tmux -S "$SOCKET" capture-pane -p -J -t "$SESSION":0.0 -S -200
+tmux -S "$SOCKET" capture-pane -p -J -t "$TARGET" -S -200
 
 # Cleanup
 tmux -S "$SOCKET" kill-session -t "$SESSION"

--- a/references/tooling.md
+++ b/references/tooling.md
@@ -37,11 +37,12 @@ SESSION="codex-review-$(date +%Y%m%d-%H%M%S)"
 
 # Start session and run codex
 tmux -S "$SOCKET" new-session -d -s "$SESSION" -n shell
-tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 -l -- "codex review --base main" Enter
+TARGET="$(tmux -S "$SOCKET" list-panes -t "$SESSION" -F "#{session_name}:#{window_index}.#{pane_index}" | head -n 1)"
+tmux -S "$SOCKET" send-keys -t "$TARGET" -l -- "codex review --base main" Enter
 
 # Monitor
 tmux -S "$SOCKET" attach -t "$SESSION"
-tmux -S "$SOCKET" capture-pane -p -J -t "$SESSION":0.0 -S -200
+tmux -S "$SOCKET" capture-pane -p -J -t "$TARGET" -S -200
 ```
 
 ## tmux-run Helper

--- a/scripts/tmux-run
+++ b/scripts/tmux-run
@@ -66,13 +66,30 @@ LOG_FILE="$LOG_DIR/${SESSION}.log"
 : > "$LOG_FILE"
 EXIT_FILE="$LOG_DIR/${SESSION}.exit"
 
-TARGET="${SESSION}:0.0"
-
 if ! tmux -S "$SOCKET" new-session -d -s "$SESSION" -n shell; then
   echo "Error: Failed to create tmux session on socket: $SOCKET" >&2
   exit 1
 fi
 tmux -S "$SOCKET" set-option -t "$SESSION" remain-on-exit on
+
+# Resolve the actual first pane target. Do not assume :0.0 because tmux
+# base-index and pane-base-index can be non-zero (for example 1.1).
+FIRST_WINDOW="$(tmux -S "$SOCKET" list-windows -t "$SESSION" -F '#{window_index}' 2>/dev/null | head -n 1 || true)"
+if [[ -z "$FIRST_WINDOW" ]]; then
+  tmux -S "$SOCKET" kill-session -t "$SESSION" || true
+  echo "Error: Failed to resolve tmux window index for session: $SESSION" >&2
+  exit 1
+fi
+
+FIRST_PANE="$(tmux -S "$SOCKET" list-panes -t "${SESSION}:${FIRST_WINDOW}" -F '#{pane_index}' 2>/dev/null | head -n 1 || true)"
+if [[ -z "$FIRST_PANE" ]]; then
+  tmux -S "$SOCKET" kill-session -t "$SESSION" || true
+  echo "Error: Failed to resolve tmux pane index for session: $SESSION" >&2
+  exit 1
+fi
+
+TARGET="${SESSION}:${FIRST_WINDOW}.${FIRST_PANE}"
+
 if ! tmux -S "$SOCKET" pipe-pane -t "$TARGET" -o "cat >> \"$LOG_FILE\""; then
   tmux -S "$SOCKET" kill-session -t "$SESSION" || true
   echo "Error: Failed to attach pipe-pane for logging" >&2


### PR DESCRIPTION
## Summary

Fixes #5 by removing the hardcoded tmux pane target (`:0.0`) from `scripts/tmux-run`.

### What changed
- `scripts/tmux-run`
  - after `new-session`, resolve the actual first window/pane indexes dynamically:
    - `list-windows -F '#{window_index}'`
    - `list-panes -F '#{pane_index}'`
  - build target as `"${SESSION}:${FIRST_WINDOW}.${FIRST_PANE}"`
  - fail fast with clear errors if window/pane discovery fails
- docs/examples updated to stop hardcoding `:0.0`:
  - `references/tooling.md`
  - `references/quick-reference.md`
  - `references/WORKFLOW.md`

## Why

OpenClaw tmux sockets can have `base-index=1` / `pane-base-index=1`. In that setup, hardcoding `:0.0` causes:
- `can't find window: 0`
- `can't find pane: 0`

Dynamic target discovery makes `tmux-run` index-agnostic.

## Validation

- `bash -n scripts/tmux-run`
- Reproduced failure before fix with a dedicated socket configured to index from 1.
- Verified after fix on the same socket:
  - session starts successfully
  - monitor hint shows target `...:1.1`
  - no `can't find window: 0` / `can't find pane: 0` error

