### PR TITLE
fix(skill): harden wrappers and AGENTS guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,107 @@
+**Current date**: 2026-02-19
+
+## Purpose
+
+High-signal instructions for coding agents in this repository.
+Keep this file concise; move long examples and deep procedures to `README.md` and `references/`.
+
+## Scope
+
+- Applies to the repository root and descendants.
+- Add nested `AGENTS.md` files only when a subdirectory needs different rules.
+- `CLAUDE.md` should remain a symlink to this file.
+
+## Language
+
+- English only for code, comments, docs, examples, commits, configs, errors, and tests.
+
+## Tooling
+
+- Prefer `rg` over `grep`.
+- Prefer `fd`/`tree` when available; fall back to `find`/`ls -R` when missing.
+- Resolve Claude CLI in this order: `~/.claude/local/claude` (if present), otherwise `claude` from `PATH`.
+- Prefer non-interactive command execution.
+
+## Runtime Reality Check
+
+- Before running major workflows, verify toolchain:
+  - `command -v codex && codex --version`
+  - `command -v timeout`
+  - `command -v gh`
+  - `command -v claude || test -x ~/.claude/local/claude`
+- If a required binary is missing, stop and report exact install/unblock steps.
+
+## Codex Command Canon
+
+- Prefer Codex for implementation and review:
+  - Implementation: `codex exec "..."` (or `codex --yolo exec "..."` only in trusted/sandboxed environments)
+  - Resume: `codex exec resume --last`
+  - Review: `codex review --base <branch> "custom focus prompt"`
+- Use `--full-auto` for sandboxed low-friction automation.
+- Use `--yolo` only when bypassing sandbox/approvals is explicitly intended.
+
+## Workflow
+
+1. Gather context with read-only operations first.
+2. For non-trivial work, propose a concise plan with assumptions, risks, and one alternative.
+3. Get explicit `APPROVE` before file writes, package installs, or system changes.
+4. After approval, execute end-to-end and report progress, results, and deviations.
+
+## Long-Running Commands
+
+- Ensure `tsx` scripts close watchers/timers and call `process.exit(0)`.
+- Wrap long tasks with process-group timeout, e.g.:
+  - `timeout -k5s 60s bash -lc 'exec npx --yes tsx scripts/tool-schema-lint.ts'`
+- Avoid `timeout --foreground`.
+- After timeout, verify child processes are stopped; if not, run `pkill -P <wrapper_pid>`.
+
+## Code Standards
+
+- Prefer KISS and YAGNI; avoid speculative abstractions.
+- Apply DRY with a three-strikes rule before abstraction.
+- Keep modules and classes focused (SRP).
+- TypeScript: avoid `any`; prefer precise types or `Record<string, unknown>`.
+- Use explicit error handling; never fail silently.
+- Import order: node -> external -> internal.
+- Use descriptive names and named constants instead of magic numbers.
+
+## Review Expectations (Plan/Review Mode)
+
+- Review in this order: Architecture, Code Quality, Tests, Performance.
+- For each issue:
+  - include file/line references,
+  - present 2-3 options (include do-nothing when reasonable),
+  - state effort, risk, impact, and maintenance burden per option,
+  - recommend one option and ask for user decision before implementation.
+- Interactive flow:
+  - Big change: section-by-section with up to 4 top issues per section.
+  - Small change: one focused question per section.
+
+## Testing and Validation
+
+- Reproduce first when debugging.
+- Before finalizing, run relevant checks:
+  - formatting/lint
+  - typecheck
+  - unit/integration/e2e tests as applicable
+- Report exact commands run and outcomes.
+- Explicitly call out checks not run and residual risk.
+
+## Documentation Hygiene
+
+- Update `README.md` or `references/` when public behavior/workflow changes.
+- Final report must summarize files changed, key diffs, and side effects.
+- Prefer inclusive language: allowlist/blocklist, primary/replica, main branch.
+
+## OpenClaw Skill Notes
+
+- Keep `SKILL.md` AgentSkills-compatible: clear `name` + `description`, concise body, references for deep detail.
+- For OpenClaw compatibility, keep frontmatter keys single-line and keep `metadata` as a single-line JSON object.
+
+## CLI Drift Check
+
+- Periodically verify docs/scripts against real CLI help:
+  - `codex --help`
+  - `codex review --help`
+  - `claude --help`
+- Update references when flags/behavior drift.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/scripts/safe-review.sh
+++ b/scripts/safe-review.sh
@@ -25,6 +25,11 @@ if [[ -z "$CLI" ]]; then
   exit 1
 fi
 
+if [[ "$CLI" != "claude" && "$CLI" != "codex" ]]; then
+  error "Unknown CLI: $CLI. Must be 'codex' or 'claude'."
+  exit 1
+fi
+
 shift # Remove CLI name from args
 
 # Check for forbidden --max-turns flag


### PR DESCRIPTION
## What
- add a concise, Codex/OpenClaw-aligned `AGENTS.md` and keep `CLAUDE.md` symlinked
- harden `scripts/safe-fallback.sh` by validating mode (`impl|review`)
- ensure custom review prompt is forwarded to `codex review`
- stop suppressing stderr in fallback tool invocations for better diagnostics
- harden `scripts/safe-review.sh` with explicit CLI allowlist (`codex|claude`)

## Why
- prevents silent misconfiguration and mode mistakes
- preserves review intent by passing custom review focus instructions
- improves failure visibility during fallback execution
- aligns project instructions with current Codex/OpenClaw/Claude behavior

## Tests
- `bash -n scripts/safe-fallback.sh scripts/safe-review.sh scripts/safe-impl.sh scripts/code-implement scripts/tmux-run`
- `shellcheck scripts/*.sh scripts/code-implement scripts/tmux-run`
- `./scripts/safe-fallback.sh nope "x"` (expects exit 1 with invalid mode)
- `./scripts/safe-review.sh nope --help` (expects exit 1 with invalid CLI)

## AI Assistance
- implemented with Codex CLI in local repo workflow
