### PR TITLE
chore(skill): add doctor + wrapper smoke CI

### DIFF
--- a/.github/workflows/wrapper-smoke.yml
+++ b/.github/workflows/wrapper-smoke.yml
@@ -1,0 +1,37 @@
+name: Wrapper Smoke Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  wrappers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: Bash syntax check
+        run: |
+          set -euo pipefail
+          while IFS= read -r script; do
+            [[ -f "$script" ]] || continue
+            bash -n "$script"
+          done < <(git ls-files scripts)
+
+      - name: Shellcheck
+        run: |
+          set -euo pipefail
+          while IFS= read -r script; do
+            [[ -f "$script" ]] || continue
+            shellcheck "$script"
+          done < <(git ls-files scripts)
+
+      - name: Wrapper smoke tests
+        run: ./scripts/smoke-wrappers.sh

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ OpenClaw skill for coding assistant using agent CLIs (Codex, Claude Code). Prima
 
 - GitHub CLI (`gh`)
 - One of: Codex CLI (`codex`) or Claude Code CLI (`claude`)
+- GNU `timeout` command (coreutils on macOS)
 - Optional: tmux (for durable TTY sessions and wrapper scripts)
 
 ## Installation
@@ -24,6 +25,16 @@ OpenClaw skill for coding assistant using agent CLIs (Codex, Claude Code). Prima
 # Clone to OpenClaw skills directory
 cd /home/art/clawd/skills
 git clone https://github.com/kesslerio/coding-agent-openclaw-skill.git coding-agent
+```
+
+## Preflight and Validation
+
+```bash
+# Verify local tooling before running wrappers
+./scripts/doctor
+
+# Run wrapper behavior smoke tests
+./scripts/smoke-wrappers.sh
 ```
 
 ## Usage

--- a/references/quick-reference.md
+++ b/references/quick-reference.md
@@ -7,6 +7,7 @@
 - Tool Fallback Chain
 - Direct CLI Commands (Primary)
 - Wrapper Scripts (Secondary)
+- Preflight Checks
 - Pre-Completion Checklist
 - Quick Reference
 - Command Reference
@@ -102,6 +103,18 @@ claude --resume
 TIMEOUT=600 ./scripts/safe-review.sh codex review --base <base> --title "PR Review"
 TIMEOUT=180 ./scripts/safe-impl.sh codex --yolo exec "Implement feature X"
 ```
+
+## Preflight Checks
+
+```bash
+# Verify local prerequisites and Claude binary resolution
+./scripts/doctor
+
+# Validate wrapper behavior
+./scripts/smoke-wrappers.sh
+```
+
+Claude is resolved in this order: `~/.claude/local/claude`, then `claude` in `PATH`.
 
 ## Pre-Completion Checklist
 
@@ -217,6 +230,8 @@ Definitions:
 | View PR | `gh pr view <PR> --json number,title,state` |
 | Checkout PR | `gh pr checkout <PR>` |
 | Review PR | `timeout 600s codex review --base <base> --title "PR #N Review"` |
+| Preflight wrappers | `./scripts/doctor` |
+| Wrapper smoke tests | `./scripts/smoke-wrappers.sh` |
 | Check CI | `gh pr checks <PR> --repo owner/repo` |
 | Merge PR | `gh pr merge <PR> --repo owner/repo --admin --merge` |
 | Resume Codex | `codex exec resume --last` |

--- a/references/tooling.md
+++ b/references/tooling.md
@@ -54,6 +54,20 @@ Agent CLIs support non-interactive execution with permission bypass and session 
 
 Sessions persist to disk (`~/.codex/sessions/` and `~/.claude/projects/<project>/`) and survive process restarts.
 
+## Preflight Checks
+
+Run preflight before wrapper use:
+
+```bash
+./scripts/doctor
+```
+
+`scripts/doctor` checks:
+- `codex`
+- `gh`
+- `timeout`
+- Claude binary resolution in this order: `~/.claude/local/claude` then `claude` in `PATH`
+
 ## Wrapper Scripts (Implementation Only)
 
 ```bash
@@ -65,6 +79,12 @@ For reviews, use direct CLI — no wrapper needed:
 ```bash
 # Detect base branch: main, master, or trunk (whichever exists)
 timeout 600s codex review --base <base> --title "Review PR #N"
+```
+
+Validate wrappers locally:
+
+```bash
+./scripts/smoke-wrappers.sh
 ```
 
 ## Advanced: tmux Wrapper (Optional)

--- a/scripts/doctor
+++ b/scripts/doctor
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# doctor - preflight checks for OpenClaw coding skill wrappers
+set -euo pipefail
+
+# Ensure standard tools are available on NixOS
+export PATH="$PATH:/run/current-system/sw/bin"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/resolve-cli.sh"
+
+failures=0
+
+check_cmd() {
+  local name="$1"
+  local remediation="$2"
+
+  if command -v "$name" &>/dev/null; then
+    printf '[ok] %s: %s\n' "$name" "$(command -v "$name")"
+  else
+    printf '[fail] %s: not found\n' "$name" >&2
+    printf '       Fix: %s\n' "$remediation" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+printf 'OpenClaw wrapper preflight\n'
+printf '==========================\n'
+
+check_cmd "codex" "npm install -g @openai/codex"
+check_cmd "gh" "brew install gh"
+check_cmd "timeout" "brew install coreutils && mkdir -p \"$HOME/.local/bin\" && ln -sf \"\$(brew --prefix coreutils)/bin/gtimeout\" \"$HOME/.local/bin/timeout\""
+
+if claude_bin="$(resolve_claude_bin)"; then
+  printf '[ok] claude: %s\n' "$claude_bin"
+else
+  printf '[fail] claude: not found (checked ~/.claude/local/claude, then PATH)\n' >&2
+  printf '       Fix (PATH install): npm install -g @anthropic-ai/claude-code\n' >&2
+  printf '       Fix (local binary): install/use ~/.claude/local/claude\n' >&2
+  failures=$((failures + 1))
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+  printf '\nPreflight failed with %s issue(s).\n' "$failures" >&2
+  exit 1
+fi
+
+printf '\nPreflight passed.\n'

--- a/scripts/lib/resolve-cli.sh
+++ b/scripts/lib/resolve-cli.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+resolve_claude_bin() {
+  local claude_local="${HOME}/.claude/local/claude"
+  if [[ -x "$claude_local" ]]; then
+    printf '%s\n' "$claude_local"
+    return 0
+  fi
+
+  if command -v claude &>/dev/null; then
+    command -v claude
+    return 0
+  fi
+
+  return 1
+}

--- a/scripts/safe-review.sh
+++ b/scripts/safe-review.sh
@@ -9,6 +9,10 @@ export PATH="$PATH:/run/current-system/sw/bin"
 # Configuration
 MIN_REVIEW_TIMEOUT=${MIN_REVIEW_TIMEOUT:-600}
 DEFAULT_TIMEOUT=${DEFAULT_TIMEOUT:-1200}
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/resolve-cli.sh"
 
 # Colors
 RED='\033[0;31m'
@@ -62,7 +66,13 @@ if [[ $TIMEOUT -lt $MIN_REVIEW_TIMEOUT ]]; then
 fi
 
 # Validate CLI exists
-if ! command -v "$CLI" &>/dev/null; then
+CLI_BIN="$CLI"
+if [[ "$CLI" == "claude" ]]; then
+  if ! CLI_BIN="$(resolve_claude_bin)"; then
+    error "Claude CLI not found (tried ~/.claude/local/claude, then PATH)."
+    exit 1
+  fi
+elif ! command -v "$CLI" &>/dev/null; then
   error "CLI '$CLI' not found in PATH"
   exit 1
 fi
@@ -84,4 +94,4 @@ fi
 
 # Execute with timeout (use ${arr[@]+...} for older bash compatibility)
 warn "Running $CLI with ${TIMEOUT}s timeout (min: ${MIN_REVIEW_TIMEOUT}s)"
-exec timeout "${TIMEOUT}s" "$CLI" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} "$@"
+exec timeout "${TIMEOUT}s" "$CLI_BIN" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} "$@"

--- a/scripts/smoke-wrappers.sh
+++ b/scripts/smoke-wrappers.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# smoke-wrappers.sh - lightweight behavior checks for wrapper scripts
+set -euo pipefail
+
+# Ensure standard tools are available on NixOS
+export PATH="$PATH:/run/current-system/sw/bin"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fake_bin="$tmp_dir/bin"
+mkdir -p "$fake_bin"
+
+cat >"$fake_bin/timeout" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ $# -lt 2 ]]; then
+  exit 2
+fi
+shift
+exec "$@"
+EOF
+
+cat >"$fake_bin/codex" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${SMOKE_CODEX_ARGS_FILE:?}"
+{
+  for arg in "$@"; do
+    printf '%s\n' "$arg"
+  done
+} >"$SMOKE_CODEX_ARGS_FILE"
+exit 0
+EOF
+
+chmod +x "$fake_bin/timeout" "$fake_bin/codex"
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fq -- "$expected" "$file"; then
+    printf 'Assertion failed: expected "%s" in %s\n' "$expected" "$file" >&2
+    printf '--- file content ---\n' >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+test_invalid_mode_rejected() {
+  local output="$tmp_dir/invalid-mode.txt"
+  if "$SCRIPT_DIR/safe-fallback.sh" bad-mode "prompt" >"$output" 2>&1; then
+    printf 'Expected safe-fallback.sh to reject invalid mode\n' >&2
+    exit 1
+  fi
+  assert_contains "$output" "invalid mode"
+}
+
+test_invalid_cli_rejected() {
+  local output="$tmp_dir/invalid-cli.txt"
+  if "$SCRIPT_DIR/safe-review.sh" bad-cli >"$output" 2>&1; then
+    printf 'Expected safe-review.sh to reject invalid CLI\n' >&2
+    exit 1
+  fi
+  assert_contains "$output" "Unknown CLI"
+}
+
+test_review_prompt_pass_through() {
+  local prompt="Review this PR thoroughly: preserve this custom prompt text and include edge-case notes for wrappers 1234567890."
+  local title="${prompt:0:100}"
+  local codex_args="$tmp_dir/codex-args.txt"
+  local output="$tmp_dir/review-pass-through.txt"
+
+  PATH="$fake_bin:$PATH" \
+  SMOKE_CODEX_ARGS_FILE="$codex_args" \
+  "$SCRIPT_DIR/safe-fallback.sh" review "$prompt" >"$output" 2>&1
+
+  assert_contains "$codex_args" "review"
+  assert_contains "$codex_args" "--title"
+  assert_contains "$codex_args" "$title"
+  assert_contains "$codex_args" "$prompt"
+}
+
+test_invalid_mode_rejected
+test_invalid_cli_rejected
+test_review_prompt_pass_through
+
+printf 'Wrapper smoke tests passed.\n'


### PR DESCRIPTION
## What
- add `scripts/doctor` preflight checks for `codex`, `gh`, `timeout`, and Claude resolution order (`~/.claude/local/claude` then `PATH`)
- add shared resolver `scripts/lib/resolve-cli.sh` and use it in:
  - `scripts/safe-impl.sh`
  - `scripts/safe-review.sh`
  - `scripts/safe-fallback.sh`
- add wrapper smoke tests in `scripts/smoke-wrappers.sh` for:
  - invalid mode rejection in `safe-fallback.sh`
  - invalid CLI rejection in `safe-review.sh`
  - review prompt pass-through behavior in `safe-fallback.sh`
- add CI workflow `.github/workflows/wrapper-smoke.yml` to run:
  - bash syntax checks
  - shellcheck
  - wrapper smoke tests
- update docs with preflight + test commands:
  - `README.md`
  - `references/tooling.md`
  - `references/quick-reference.md`

## Why
- reduce wrapper failures caused by missing local tooling and inconsistent Claude binary locations
- catch wrapper regressions automatically in CI
- make preflight and validation steps explicit for contributors

## Tests
- `while IFS= read -r script; do [[ -f "$script" ]] || continue; bash -n "$script"; done < <(git ls-files scripts)`
- `while IFS= read -r script; do [[ -f "$script" ]] || continue; shellcheck "$script"; done < <(git ls-files scripts)`
- `./scripts/smoke-wrappers.sh`
- `./scripts/doctor`
- `PATH='/usr/bin:/bin' ./scripts/doctor` (expect non-zero)

## AI Assistance
- AI-assisted: yes
- Testing level: fully tested
- Prompt/session log: Codex CLI session
- I understand this code: yes

Closes #12
