### PR TITLE
chore(repo): add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug Report
+description: Report a reproducible defect in wrappers, docs, or workflows.
+title: "bug: <symptom> when <condition>"
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Provide exact commands, outputs, and environment details so maintainers can reproduce quickly.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Concrete bug statement with expected vs actual behavior.
+      placeholder: "When running X, Y fails with Z. Expected ..."
+    validations:
+      required: true
+  - type: textarea
+    id: repro_steps
+    attributes:
+      label: Reproduction Steps
+      description: Exact, ordered commands and setup.
+      placeholder: |
+        1. cd /path/to/repo
+        2. export FOO=bar
+        3. ./scripts/... 
+    validations:
+      required: true
+  - type: textarea
+    id: expected_actual
+    attributes:
+      label: Expected vs Actual
+      placeholder: |
+        Expected:
+        Actual:
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and Evidence
+      description: Paste exact output, stack traces, CI links, screenshots, or references.
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: commit
+    attributes:
+      label: Commit / Ref
+      description: Branch, commit SHA, or PR where issue was observed.
+      placeholder: main@<sha> or PR #123
+    validations:
+      required: true
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      options:
+        - macOS
+        - Linux
+        - CI (GitHub Actions)
+        - Other
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security disclosure
+    url: https://github.com/kesslerio/coding-agent-openclaw-skill/security/advisories/new
+    about: Please report security vulnerabilities privately.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: Feature Request
+description: Propose a capability improvement with clear scope and tradeoffs.
+title: "feat: <capability> (for <surface>)"
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Keep this concrete. If possible, include command-level examples and clear acceptance criteria.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What user/workflow pain exists today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Change
+      description: Describe behavior, CLI/docs impact, and constraints.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Include at least one alternative and why it is less preferred.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Use a testable checklist.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: examples
+    attributes:
+      label: Example Commands / Usage
+      description: Exact commands or snippets showing desired behavior.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task_chore.yml
+++ b/.github/ISSUE_TEMPLATE/task_chore.yml
@@ -1,0 +1,51 @@
+name: Task / Chore
+description: Track non-feature maintenance work.
+title: "TODO: <cleanup> after <dependency>"
+labels:
+  - chore
+body:
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What should be completed and why now?
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Include in-scope and out-of-scope bullets.
+      placeholder: |
+        In scope:
+        - ...
+
+        Out of scope:
+        - ...
+    validations:
+      required: true
+  - type: textarea
+    id: plan
+    attributes:
+      label: Proposed Plan
+      description: Ordered implementation steps.
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification
+      description: Exact commands/checks that confirm completion.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks and Rollback
+      description: Main risks and how to revert safely if needed.
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## What
+- 
+
+## Why
+- 
+
+## Scope
+- In scope:
+  - 
+- Out of scope:
+  - 
+
+## Tests
+- Exact commands run:
+  - `...`
+- Results:
+  - `PASS/FAIL` with key output notes
+
+## Risk and Rollback
+- Risk level: low | medium | high
+- Main risks:
+  - 
+- Rollback plan:
+  - 
+
+## AI Assistance
+- AI-assisted: yes/no
+- Tools/agents used:
+  - 
+- Human validation performed:
+  - 


### PR DESCRIPTION
## What
- add GitHub issue templates under `.github/ISSUE_TEMPLATE/`:
  - `bug_report.yml`
  - `feature_request.yml`
  - `task_chore.yml`
- add issue template config `.github/ISSUE_TEMPLATE/config.yml` to disable blank issues and route security reports to private advisories
- add `.github/pull_request_template.md` with required sections for:
  - What / Why / Scope
  - exact test commands and outcomes
  - risk and rollback
  - AI assistance disclosure

## Why
- standardize issue and PR quality
- reduce review back-and-forth by requiring reproducible commands and explicit verification details

## Tests
- `ruby -e 'require "yaml"; Dir[".github/ISSUE_TEMPLATE/*.yml"].each{|f| YAML.load_file(f); puts "ok #{f}" }'`

## AI Assistance
- AI-assisted: yes
- Testing level: lightly tested
- Prompt/session log: Codex CLI session
- I understand this code: yes

Closes #13
