### PR TITLE
feat(skill): codex policy matrix and drift checks

### DIFF
--- a/.github/workflows/wrapper-smoke.yml
+++ b/.github/workflows/wrapper-smoke.yml
@@ -33,5 +33,8 @@ jobs:
             shellcheck "$script"
           done < <(git ls-files scripts)
 
+      - name: Codex doc drift checks
+        run: ./scripts/doc-drift-check
+
       - name: Wrapper smoke tests
         run: ./scripts/smoke-wrappers.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ For script changes, run:
 ```bash
 while IFS= read -r script; do [[ -f "$script" ]] || continue; bash -n "$script"; done < <(git ls-files scripts)
 while IFS= read -r script; do [[ -f "$script" ]] || continue; shellcheck "$script"; done < <(git ls-files scripts)
+./scripts/doc-drift-check
 ./scripts/smoke-wrappers.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ timeout 600s codex review --base <base> --title "Review PR #N"
 ./scripts/code-implement "Implement feature X"
 ```
 
+Implementation mode policy can be configured:
+
+```bash
+export CODING_AGENT_IMPL_MODE=direct  # direct|tmux|auto
+```
+
 ## Files
 
 - `SKILL.md` — Full skill documentation (includes Dev persona)
@@ -79,6 +85,7 @@ timeout 600s codex review --base <base> --title "Review PR #N"
 - `references/STANDARDS.md` — Coding standards & rules
 - `references/quick-reference.md` — Command quick reference
 - `references/tooling.md` — CLI usage, session management, timeouts
+- `references/codex-cli.md` — Canonical Codex CLI reference and policy matrix
 - `references/claude-code.md` — Claude Code CLI reference and session resume
 - `references/reviews.md` — Review + PR/issue writing patterns
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -57,7 +57,7 @@ Full issue → implement → PR → review → fix cycle using session resume:
 
 ## Non-Negotiable Rules (Summary)
 
-1. **Use agent CLIs** — Never write code directly. Use Codex CLI or Claude Code CLI (direct or via tmux wrappers). No MCP.
+1. **Use agent CLIs** — Never write code directly. Use Codex CLI or Claude Code CLI (direct or via tmux wrappers). Do not switch to MCP orchestration unless explicitly required.
 2. **Feature branch** — Always use a feature branch for changes.
 3. **PR before done** — Always create a PR before completion.
 4. **GitHub hygiene** — Precise titles, structured bodies, explicit test commands, AI disclosure.
@@ -88,6 +88,10 @@ Reviews:        Codex CLI (direct) → Claude CLI → BLOCKED
 ⛔ NEVER skip to direct edits — request user override instead
 ```
 
+Implementation mode is configurable:
+- `CODING_AGENT_IMPL_MODE=direct|tmux|auto` (default: `direct`)
+- `auto` selects tmux first only when running in an interactive TTY with tmux available
+
 ## Tooling + Workflow References
 
 Read these before doing any work:
@@ -95,6 +99,7 @@ Read these before doing any work:
 - `references/STANDARDS.md` for coding standards and limits
 - `references/quick-reference.md` for commands and guardrails
 - `references/tooling.md` for CLI usage, session management, and timeouts
+- `references/codex-cli.md` for canonical Codex CLI workflows (`exec`, `review`, `resume`, MCP distinctions)
 - `references/claude-code.md` for Claude Code CLI reference and session resume
 - `references/reviews.md` for review formats and GH review posting
 - `references/examples.md` for violation examples and recovery

--- a/references/WORKFLOW.md
+++ b/references/WORKFLOW.md
@@ -167,7 +167,7 @@ Use this block in completion messages:
 
 ### Primary: Direct CLI
 
-Use agent CLIs directly for most tasks. Session resume preserves full context across phases.
+Use agent CLIs directly for most tasks. Session resume preserves full context across phases and is preferred over spawning sub-agents for routine implementation.
 
 ```bash
 # Implementation (Codex)
@@ -312,15 +312,20 @@ claude -p --resume <session-id> "Continue from here"
 ```
 
 See `references/claude-code.md` for full Claude Code reference.
+See `references/codex-cli.md` for canonical Codex execution policy (`exec`, `resume`, MCP distinctions).
 See `references/tooling.md` for tmux wrappers, timeouts, and environment variables.
 
 ## Agent Utilization
 
-Delegate specific tasks to focused agents:
+Delegate specific tasks to focused agents only when decomposition is clear and parallelizable:
 
 - **requirements-specialist**: Specs → GitHub Issues
 - **implementation-architect**: API/UI Design
 - **quality-assurance-specialist**: Tests, Security, Perf
 - **docs-architect**: Documentation updates
 
-**Trigger**: When a task is too complex for a single prompt, spawn a sub-agent with a specific role.
+**Trigger**: Use sub-agents for independent tracks (for example: separate security/performance/test review streams). Keep single-agent `codex exec` + `codex exec resume` as the default path for implementation loops.
+
+Sub-agent note:
+- Codex multi-agent workflows are experimental.
+- Non-interactive approval handling can fail if sub-agents request escalation unexpectedly.

--- a/references/codex-cli.md
+++ b/references/codex-cli.md
@@ -1,0 +1,96 @@
+# Codex CLI Reference
+
+Canonical Codex guidance for this skill.
+
+## Default Strategy
+
+Use **single-agent Codex** for most work:
+1. `codex --yolo exec "..."` for one-off implementation/review prompts.
+2. `codex exec resume --last "..."` for follow-up work on the same task.
+3. Use tmux only when terminal persistence/reattach is required.
+
+This keeps workflows interactive and stateful without forcing a persistent tmux session.
+
+## Core Commands
+
+### One-off implementation
+
+```bash
+codex --yolo exec "Implement feature X. No questions."
+```
+
+### Resume previous context
+
+```bash
+codex exec resume --last "Fix findings from the previous run"
+```
+
+### Review against base branch
+
+```bash
+timeout 600s codex review --base <base> --title "PR #N Review"
+```
+
+### Structured non-interactive output
+
+```bash
+codex exec --json --output-last-message /tmp/last.txt "Summarize changes"
+```
+
+Useful automation flags:
+- `--json`
+- `--output-schema <FILE>`
+- `--output-last-message <FILE>`
+- `--skip-git-repo-check`
+
+## Safety Profiles
+
+Choose one profile per run:
+
+- Guardrailed sandbox: `codex exec --full-auto "..."`
+- Full bypass (externally sandboxed environments only):
+
+```bash
+codex exec --dangerously-bypass-approvals-and-sandbox "..."
+```
+
+`codex --yolo exec` is equivalent to bypass mode.
+
+## Execution Policy Matrix
+
+| Task | Primary | Secondary | Notes |
+|------|---------|-----------|-------|
+| Implementation | direct `codex exec` | tmux transport | Use `resume` for iterative loops |
+| PR review | `codex review --base` | Claude CLI fallback | Keep timeout >= 600s |
+| Long-running implementation | tmux transport | direct `codex exec` | For reattach/log durability |
+
+Implementation-mode env var:
+- `CODING_AGENT_IMPL_MODE=direct|tmux|auto`
+- `direct`: run Codex directly first
+- `tmux`: run tmux transport first
+- `auto`: tmux first only when attached to TTY and tmux is available
+
+## MCP Clarification
+
+There are two distinct MCP paths:
+
+1. `codex mcp ...`
+- Configure external MCP tools **for Codex**.
+- Use when Codex needs extra context/tools.
+
+2. `codex mcp-server`
+- Expose **Codex itself** as an MCP server for another orchestrator.
+- Experimental; use behind feature flags/pilots.
+
+## Multi-Agent Guidance
+
+Codex multi-agent workflows are experimental.
+
+Use only when the task is truly decomposable into parallel tracks (for example: independent security/performance/test-review streams). Prefer single-agent `exec` + `resume` for normal implementation cycles.
+
+## Official Sources
+
+- https://developers.openai.com/codex/cli/reference
+- https://developers.openai.com/codex/noninteractive
+- https://developers.openai.com/codex/mcp
+- https://developers.openai.com/codex/multi-agent

--- a/references/quick-reference.md
+++ b/references/quick-reference.md
@@ -59,6 +59,10 @@ Reviews:        Codex CLI (direct) → Claude CLI → BLOCKED
 ⛔ NEVER skip to direct edits — request user override instead
 ```
 
+Implementation mode routing:
+- `CODING_AGENT_IMPL_MODE=direct|tmux|auto` (default: `direct`)
+- `auto` -> tmux-first only in interactive TTY + tmux available; otherwise direct-first
+
 ## Direct CLI Commands (Primary)
 
 ### Codex
@@ -110,11 +114,14 @@ TIMEOUT=180 ./scripts/safe-impl.sh codex --yolo exec "Implement feature X"
 # Verify local prerequisites and Claude binary resolution
 ./scripts/doctor
 
+# Verify Codex command/flag drift before editing command docs
+./scripts/doc-drift-check
+
 # Validate wrapper behavior
 ./scripts/smoke-wrappers.sh
 ```
 
-Claude is resolved in this order: `~/.claude/local/claude`, then `claude` in `PATH`.
+Claude is resolved in this order: `CODING_AGENT_CLAUDE_BIN` → `~/.claude/local/claude` → `claude` in `PATH`.
 
 ## Pre-Completion Checklist
 
@@ -231,6 +238,7 @@ Definitions:
 | Checkout PR | `gh pr checkout <PR>` |
 | Review PR | `timeout 600s codex review --base <base> --title "PR #N Review"` |
 | Preflight wrappers | `./scripts/doctor` |
+| Codex doc drift check | `./scripts/doc-drift-check` |
 | Wrapper smoke tests | `./scripts/smoke-wrappers.sh` |
 | Check CI | `gh pr checks <PR> --repo owner/repo` |
 | Merge PR | `gh pr merge <PR> --repo owner/repo --admin --merge` |

--- a/references/reviews.md
+++ b/references/reviews.md
@@ -69,7 +69,11 @@
 # Code review (direct CLI)
 timeout 600s codex review --base <base> --title "PR #N Review"
 
-# Standards review (tmux)
+# Standards review (direct CLI, preferred)
+timeout 1200s codex --yolo exec -c model_reasoning_effort="medium" \
+  "Review against coding standards in references/STANDARDS.md. Report PASS/FAIL per category with file:line refs."
+
+# Standards review (tmux transport, optional for persistence)
 ./scripts/tmux-run timeout 1200s codex --yolo exec -c model_reasoning_effort="medium" \
   "Review against coding standards in references/STANDARDS.md. Report PASS/FAIL per category with file:line refs."
 ```

--- a/scripts/doc-drift-check
+++ b/scripts/doc-drift-check
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# doc-drift-check - verify documented Codex commands/flags still exist
+set -euo pipefail
+
+# Ensure standard tools are available on NixOS
+export PATH="$PATH:/run/current-system/sw/bin"
+
+if ! command -v codex >/dev/null 2>&1; then
+  echo "Error: codex not found in PATH" >&2
+  exit 1
+fi
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+
+  if ! grep -Fq -- "$needle" <<<"$haystack"; then
+    echo "[fail] missing '${needle}' in ${label}" >&2
+    return 1
+  fi
+
+  echo "[ok] ${label}: ${needle}" >&2
+}
+
+root_help="$(codex --help)"
+exec_help="$(codex exec --help)"
+review_help="$(codex review --help)"
+resume_help="$(codex exec resume --help)"
+mcp_help="$(codex mcp --help)"
+
+assert_contains "$root_help" "exec" "codex --help"
+assert_contains "$root_help" "review" "codex --help"
+assert_contains "$root_help" "mcp" "codex --help"
+assert_contains "$root_help" "mcp-server" "codex --help"
+assert_contains "$root_help" "resume" "codex --help"
+
+assert_contains "$exec_help" "--json" "codex exec --help"
+assert_contains "$exec_help" "--output-schema" "codex exec --help"
+assert_contains "$exec_help" "--output-last-message" "codex exec --help"
+assert_contains "$exec_help" "--skip-git-repo-check" "codex exec --help"
+assert_contains "$exec_help" "--full-auto" "codex exec --help"
+assert_contains "$exec_help" "--dangerously-bypass-approvals-and-sandbox" "codex exec --help"
+
+assert_contains "$review_help" "--base" "codex review --help"
+assert_contains "$resume_help" "--last" "codex exec resume --help"
+assert_contains "$mcp_help" "add" "codex mcp --help"
+
+echo "Codex doc drift checks passed." >&2

--- a/scripts/doctor
+++ b/scripts/doctor
@@ -34,11 +34,18 @@ check_cmd "timeout" "brew install coreutils && mkdir -p \"$HOME/.local/bin\" && 
 if claude_bin="$(resolve_claude_bin)"; then
   printf '[ok] claude: %s\n' "$claude_bin"
 else
-  printf '[fail] claude: not found (checked ~/.claude/local/claude, then PATH)\n' >&2
-  printf '       Fix (PATH install): npm install -g @anthropic-ai/claude-code\n' >&2
-  printf '       Fix (local binary): install/use ~/.claude/local/claude\n' >&2
+  if [[ -n "${CODING_AGENT_CLAUDE_BIN:-}" ]]; then
+    printf '[fail] claude: CODING_AGENT_CLAUDE_BIN is set but not executable: %s\n' "${CODING_AGENT_CLAUDE_BIN}" >&2
+    printf '       Fix: unset CODING_AGENT_CLAUDE_BIN or point it to a valid Claude binary\n' >&2
+  else
+    printf '[fail] claude: not found (checked CODING_AGENT_CLAUDE_BIN, ~/.claude/local/claude, then PATH)\n' >&2
+    printf '       Fix (PATH install): npm install -g @anthropic-ai/claude-code\n' >&2
+    printf '       Fix (local binary): install/use ~/.claude/local/claude\n' >&2
+  fi
   failures=$((failures + 1))
 fi
+
+printf '[info] implementation mode default: %s (set CODING_AGENT_IMPL_MODE=direct|tmux|auto to override)\n' "${CODING_AGENT_IMPL_MODE:-direct}"
 
 if [[ "$failures" -gt 0 ]]; then
   printf '\nPreflight failed with %s issue(s).\n' "$failures" >&2

--- a/scripts/lib/resolve-cli.sh
+++ b/scripts/lib/resolve-cli.sh
@@ -2,6 +2,14 @@
 set -euo pipefail
 
 resolve_claude_bin() {
+  if [[ -n "${CODING_AGENT_CLAUDE_BIN:-}" ]]; then
+    if [[ -x "${CODING_AGENT_CLAUDE_BIN}" ]]; then
+      printf '%s\n' "${CODING_AGENT_CLAUDE_BIN}"
+      return 0
+    fi
+    return 1
+  fi
+
   local claude_local="${HOME}/.claude/local/claude"
   if [[ -x "$claude_local" ]]; then
     printf '%s\n' "$claude_local"

--- a/scripts/safe-review.sh
+++ b/scripts/safe-review.sh
@@ -69,7 +69,11 @@ fi
 CLI_BIN="$CLI"
 if [[ "$CLI" == "claude" ]]; then
   if ! CLI_BIN="$(resolve_claude_bin)"; then
-    error "Claude CLI not found (tried ~/.claude/local/claude, then PATH)."
+    if [[ -n "${CODING_AGENT_CLAUDE_BIN:-}" ]]; then
+      error "CODING_AGENT_CLAUDE_BIN is set but not executable: ${CODING_AGENT_CLAUDE_BIN}"
+    else
+      error "Claude CLI not found (tried CODING_AGENT_CLAUDE_BIN, ~/.claude/local/claude, then PATH)."
+    fi
     exit 1
   fi
 elif ! command -v "$CLI" &>/dev/null; then


### PR DESCRIPTION
## Summary

- Problem: Codex is primary but lacked canonical CLI reference guidance, and wrapper runtime behavior drifted from docs.
- Why it matters: inconsistent execution policy made it unclear when to use direct exec/resume vs tmux, especially across NixOS/macOS setups.
- What changed: added canonical Codex reference, implemented configurable impl routing (`CODING_AGENT_IMPL_MODE`), added explicit Claude binary override (`CODING_AGENT_CLAUDE_BIN`), and added Codex doc drift checks in CI.
- What did not change (scope boundary): no new product/runtime dependencies beyond existing CLI requirements.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Scripts/wrappers
- [x] Skill docs/references
- [ ] Issue/PR templates or community files
- [x] CI/workflows
- [ ] Other

## Linked Issue/PR

- Closes #17
- Related #13

## User-visible / Behavior Changes

- Added `references/codex-cli.md` as canonical Codex workflow/policy guide.
- Implementation wrapper routing is now configurable via `CODING_AGENT_IMPL_MODE=direct|tmux|auto` (default `direct`).
- Claude binary resolution now supports explicit override with `CODING_AGENT_CLAUDE_BIN`.
- Added `scripts/doc-drift-check` and CI execution to detect stale Codex command/flag docs.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) -> No
- Secrets/tokens handling changed? (`Yes/No`) -> No
- New/changed network calls? (`Yes/No`) -> No
- Tool execution surface changed? (`Yes/No`) -> Yes
- If any `Yes`, explain risk + mitigation:
  - Risk: wrapper routing defaults and fallback order changed for implementation mode.
  - Mitigation: explicit env var controls, backward-compatible legacy knobs, smoke tests, and doc updates.

## Repro + Verification

### Environment

- OS: macOS (local validation)
- Shell/runtime: zsh + bash scripts
- Relevant tool versions: codex-cli 0.98.0, gh 2.73.0, timeout (GNU coreutils) 9.7

### Steps

1. Run script syntax checks on all `scripts/*`.
2. Run shellcheck on all `scripts/*`.
3. Run `./scripts/doc-drift-check`.
4. Run `./scripts/smoke-wrappers.sh`.

### Expected

- All checks pass.

### Actual

- All checks passed.

## Evidence

- [x] Failing output before + passing output after
- [x] Log snippets
- [ ] Screenshot/recording
- [ ] N/A (docs-only or template-only change)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `safe-fallback.sh` rejects invalid `CODING_AGENT_IMPL_MODE`.
  - direct mode uses `codex --yolo exec` in smoke tests.
  - `doc-drift-check` validates documented Codex flags/commands.
- Edge cases checked:
  - `CODING_AGENT_CLAUDE_BIN` invalid path error handling in wrapper scripts.
  - legacy `CODEX_TMUX_DISABLE` / `CODEX_TMUX_REQUIRED` compatibility path retained.
- What you did not verify:
  - Full NixOS runtime behavior on target host.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) -> Yes (legacy tmux env knobs still honored)
- Config/env changes? (`Yes/No`) -> Yes (`CODING_AGENT_IMPL_MODE`, `CODING_AGENT_CLAUDE_BIN`)
- Migration needed? (`Yes/No`) -> No
- If yes, exact upgrade steps:
  - Optional: set `CODING_AGENT_IMPL_MODE` and/or `CODING_AGENT_CLAUDE_BIN` for environment-specific behavior.

## Failure Recovery

- How to disable/revert this change quickly:
  - Revert commit `0888009`, or set `CODING_AGENT_IMPL_MODE=tmux` to mimic prior tmux-first behavior.
- Files/config to restore:
  - `scripts/safe-fallback.sh`, `scripts/safe-impl.sh`, `scripts/lib/resolve-cli.sh`, docs in `references/*`.
- Known bad symptoms reviewers should watch for:
  - unexpected implementation mode routing if env vars are misconfigured.

## Risks and Mitigations

- Risk:
  - routing behavior misunderstanding during transition.
  - Mitigation:
    - explicit policy matrix in docs and smoke test coverage for direct mode and invalid mode handling.

## AI Assistance

- AI-assisted: yes
- Tools/agents/models used: Codex CLI + local shell checks
- Testing level: fully tested (for modified scripts/docs checks)
- Human understanding confirmation: yes
