### PR TITLE
docs(skill): default codex implementation to high reasoning

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -34,9 +34,13 @@ Plan artifacts are written to `.ai/plans/*.md` with machine-checkable status met
 
 Agent CLIs now support non-interactive execution with full autonomy and session persistence:
 
+Reasoning default policy for Codex implementation:
+- Use `-c model_reasoning_effort="high"` for feature implementation and architectural refactors.
+- Use `medium`/`low` for simple fixes, docs-only updates, or when the user explicitly asks for fast/cheap execution.
+
 ```bash
 # Codex — full autonomy, no TTY needed
-codex --yolo exec "Implement feature X. No questions."
+codex --yolo exec -c model_reasoning_effort="high" "Implement feature X. No questions."
 codex exec resume --last    # restore context from last session
 
 # Claude Code — full autonomy, no TTY needed
@@ -58,7 +62,7 @@ For long-running implementation tasks where TTY logging and session durability a
 
 Full issue → implement → PR → review → fix cycle using session resume:
 
-1. **Implement**: `codex --yolo exec "Implement feature from issue #N"`
+1. **Implement**: `codex --yolo exec -c model_reasoning_effort="high" "Implement feature from issue #N"`
 2. **Create PR**: `gh pr create --title "feat: ..." --body "..."`
 3. **Review**: `timeout 600s codex review --base <base> --title "Review PR #N"`
 4. **Fix issues**: `codex exec resume --last` (context preserved)

--- a/references/WORKFLOW.md
+++ b/references/WORKFLOW.md
@@ -65,7 +65,8 @@ These are non-negotiable requirements. Violating any of these means the task has
 - When user specifies "use claude/codex/gemini": **MUST** use that CLI tool when available/configured
 - **MUST** use agent CLI (direct or tmux wrappers) — not direct file edits
 - For reviews: use direct `codex review --base <base>` or `claude -p`
-- For implementation: prefer direct CLI (`codex --yolo exec`) or `scripts/code-implement`
+- For implementation: prefer direct CLI (`codex --yolo exec -c model_reasoning_effort="high"`) or `scripts/code-implement`
+- Default reasoning policy: use `high` for feature implementation and architectural refactors; use `medium`/`low` only for simple fixes/docs or explicit fast/cheap requests
 - **MUST NOT** use direct file edits when agent CLI is specified
 - **MUST** document which tool was used in PR description
 - **Violation Response**: Stop and switch to specified tool
@@ -171,7 +172,7 @@ Use agent CLIs directly for most tasks. Session resume preserves full context ac
 
 ```bash
 # Implementation (Codex)
-codex --yolo exec "Implement feature X. No questions."
+codex --yolo exec -c model_reasoning_effort="high" "Implement feature X. No questions."
 
 # Implementation (Claude)
 claude -p --dangerously-skip-permissions "Implement feature X"
@@ -225,7 +226,7 @@ For complex tasks spanning multiple phases, use session resume to preserve full 
 
 ```bash
 # Phase 1: Implement from issue
-codex --yolo exec "Implement feature described in issue #42. No questions."
+codex --yolo exec -c model_reasoning_effort="high" "Implement feature described in issue #42. No questions."
 
 # Phase 2: Create PR
 gh pr create --title "feat(auth): add JWT validation" --body "..."
@@ -288,10 +289,11 @@ For automated runs with full autonomy:
 
 ```bash
 # Implementation (full autonomy)
-codex --yolo exec "Implement feature X. No questions."
+codex --yolo exec -c model_reasoning_effort="high" "Implement feature X. No questions."
 
-# With reasoning effort
-codex -c 'model_reasoning_effort="medium"' --yolo exec "Complex refactor..."
+# Simple fix/docs or explicit fast/cheap request
+codex --yolo exec -c model_reasoning_effort="medium" "Fix typo in one file"
+codex --yolo exec -c model_reasoning_effort="low" "Update README command example quickly"
 
 # Resume last session
 codex exec resume --last

--- a/references/codex-cli.md
+++ b/references/codex-cli.md
@@ -5,18 +5,22 @@ Canonical Codex guidance for this skill.
 ## Default Strategy
 
 Use **single-agent Codex** for most work:
-1. `codex --yolo exec "..."` for one-off implementation/review prompts.
+1. `codex --yolo exec -c model_reasoning_effort="high" "..."` for one-off implementation/refactor prompts.
 2. `codex exec resume --last "..."` for follow-up work on the same task.
 3. Use tmux only when terminal persistence/reattach is required.
 
 This keeps workflows interactive and stateful without forcing a persistent tmux session.
+
+Reasoning default policy:
+- Use `high` for feature implementation and architectural refactors.
+- Use `medium`/`low` only for simple fixes/docs tasks or when the user explicitly asks for fast/cheap execution.
 
 ## Core Commands
 
 ### One-off implementation
 
 ```bash
-codex --yolo exec "Implement feature X. No questions."
+codex --yolo exec -c model_reasoning_effort="high" "Implement feature X. No questions."
 ```
 
 ### Resume previous context
@@ -60,9 +64,9 @@ codex exec --dangerously-bypass-approvals-and-sandbox "..."
 
 | Task | Primary | Secondary | Notes |
 |------|---------|-----------|-------|
-| Implementation | direct `codex exec` | tmux transport | Use `resume` for iterative loops |
+| Implementation | direct `codex exec` with `-c model_reasoning_effort="high"` | tmux transport | Use `resume` for iterative loops; use `medium`/`low` only for simple/docs or fast/cheap requests |
 | PR review | `codex review --base` | Claude CLI fallback | Keep timeout >= 600s |
-| Long-running implementation | tmux transport | direct `codex exec` | For reattach/log durability |
+| Long-running implementation | tmux transport | direct `codex exec` with `-c model_reasoning_effort="high"` | For reattach/log durability |
 
 Implementation-mode env var:
 - `CODING_AGENT_IMPL_MODE=direct|tmux|auto`

--- a/references/examples.md
+++ b/references/examples.md
@@ -41,8 +41,8 @@ codex exec "Part 1" && codex exec "Part 2"
 ```
 Correct:
 ```bash
-timeout 300s codex --yolo exec "Part 1"
-timeout 300s codex --yolo exec "Part 2"
+timeout 300s codex --yolo exec -c model_reasoning_effort="high" "Part 1"
+timeout 300s codex --yolo exec -c model_reasoning_effort="high" "Part 2"
 ```
 
 ## Real Violation Examples

--- a/references/quick-reference.md
+++ b/references/quick-reference.md
@@ -69,11 +69,12 @@ Implementation mode routing:
 ### Codex
 
 ```bash
-# Implementation (full autonomy)
-codex --yolo exec "Implement feature X. No questions."
+# Implementation default (feature work / architectural refactor)
+codex --yolo exec -c model_reasoning_effort="high" "Implement feature X. No questions."
 
-# With reasoning effort
-codex -c 'model_reasoning_effort="medium"' --yolo exec "Complex refactor..."
+# Simple fix/docs or explicit fast/cheap request
+codex --yolo exec -c model_reasoning_effort="medium" "Fix typo in one file"
+codex --yolo exec -c model_reasoning_effort="low" "Update README command example quickly"
 
 # Resume last session (context preserved)
 codex exec resume --last
@@ -119,7 +120,7 @@ claude --resume
 
 # Enforcement wrappers
 TIMEOUT=600 ./scripts/safe-review.sh codex review --base <base> --title "PR Review"
-TIMEOUT=180 ./scripts/safe-impl.sh codex --yolo exec "Implement feature X"
+TIMEOUT=180 ./scripts/safe-impl.sh codex --yolo exec -c model_reasoning_effort="high" "Implement feature X"
 ```
 
 ## Preflight Checks
@@ -165,7 +166,7 @@ For plan-first flow, use `/plan <task>` (maps to `scripts/code-plan`).
 
 **Codex — full autonomy:**
 ```bash
-codex --yolo exec "Your task. No questions."
+codex --yolo exec -c model_reasoning_effort="high" "Your task. No questions."
 ```
 
 **Codex — resume session:**
@@ -288,7 +289,7 @@ SESSION=codex-impl
 
 tmux -S "$SOCKET" new-session -d -s "$SESSION" -n shell
 TARGET="$(tmux -S "$SOCKET" list-panes -t "$SESSION" -F "#{session_name}:#{window_index}.#{pane_index}" | head -n 1)"
-tmux -S "$SOCKET" send-keys -t "$TARGET" -l -- "codex --yolo exec 'Implement feature X'"
+tmux -S "$SOCKET" send-keys -t "$TARGET" -l -- "codex --yolo exec -c model_reasoning_effort=\"high\" 'Implement feature X'"
 tmux -S "$SOCKET" send-keys -t "$TARGET" Enter
 
 # Monitor

--- a/references/tooling.md
+++ b/references/tooling.md
@@ -13,9 +13,9 @@
 | Task | Primary | Secondary | Notes |
 |------|---------|-----------|-------|
 | Plan mode | `scripts/code-plan --engine codex` | `scripts/code-plan --engine claude` | Read-only planning artifact + approval gate |
-| Implementation | direct `codex --yolo exec` | tmux transport | Use `codex exec resume --last` for follow-up |
+| Implementation | direct `codex --yolo exec -c model_reasoning_effort="high"` | tmux transport | Default `high` for feature/architectural work; use `medium`/`low` for simple/docs or fast/cheap requests |
 | PR review | `codex review --base <base>` | Claude CLI | Keep timeout >= 600s |
-| Long-running implementation | tmux transport | direct `codex --yolo exec` | Use tmux when persistence/reattach is required |
+| Long-running implementation | tmux transport | direct `codex --yolo exec -c model_reasoning_effort="high"` | Use tmux when persistence/reattach is required |
 
 Implementation routing is configurable:
 
@@ -29,11 +29,15 @@ Default behavior: `direct`.
 
 Agent CLIs support non-interactive execution with permission bypass and session resume.
 
+Reasoning defaults for Codex implementation:
+- `high` for feature implementation and architectural refactors.
+- `medium`/`low` for simple fixes, docs-only work, or explicit fast/cheap requests.
+
 ### Codex CLI
 
 | Command | Purpose |
 |---------|---------|
-| `codex --yolo exec "prompt"` | Full-autonomy implementation |
+| `codex --yolo exec -c model_reasoning_effort="high" "prompt"` | Full-autonomy implementation (default for feature/architectural work) |
 | `codex exec resume --last "follow-up"` | Resume previous context |
 | `codex review --base <base>` | Code review against base branch |
 | `codex exec --json "prompt"` | Structured event stream for automation |
@@ -150,7 +154,7 @@ SESSION="codex-impl-$(date +%Y%m%d-%H%M%S)"
 # Start session and run codex
 tmux -S "$SOCKET" new-session -d -s "$SESSION" -n shell
 TARGET="$(tmux -S "$SOCKET" list-panes -t "$SESSION" -F "#{session_name}:#{window_index}.#{pane_index}" | head -n 1)"
-tmux -S "$SOCKET" send-keys -t "$TARGET" -l -- "codex --yolo exec 'Implement feature X'"
+tmux -S "$SOCKET" send-keys -t "$TARGET" -l -- "codex --yolo exec -c model_reasoning_effort=\"high\" 'Implement feature X'"
 tmux -S "$SOCKET" send-keys -t "$TARGET" Enter
 
 # Monitor
@@ -165,11 +169,11 @@ tmux -S "$SOCKET" capture-pane -p -J -t "$TARGET" -S -200
 ```bash
 # Run an implementation command in tmux (non-blocking)
 CODEX_TMUX_SESSION_PREFIX=codex-impl \
-  ./scripts/tmux-run timeout 180s codex --yolo exec "Implement feature X"
+  ./scripts/tmux-run timeout 180s codex --yolo exec -c model_reasoning_effort="high" "Implement feature X"
 
 # Run a long implementation in tmux and wait for completion
 CODEX_TMUX_SESSION_PREFIX=codex-impl \
-  ./scripts/tmux-run --wait timeout 600s codex --yolo exec "Complex multi-file refactor"
+  ./scripts/tmux-run --wait timeout 600s codex --yolo exec -c model_reasoning_effort="high" "Complex multi-file refactor"
 ```
 
 Logs: `${XDG_STATE_HOME:-$HOME/.local/state}/openclaw/tmux/<session>.log`


### PR DESCRIPTION
## What
- set explicit policy: feature implementation and architectural refactors should default to high reasoning for Codex exec
- updated implementation command snippets across skill docs to include `-c model_reasoning_effort="high"`
- documented medium/low as exceptions for simple docs/fixes or explicit fast/cheap requests
- kept review guidance unchanged

## Why
- improves first-pass implementation quality and reduces review churn
- makes default behavior explicit and consistent across references

## Tests
- `rg -n "model_reasoning_effort|codex --yolo exec" SKILL.md references/quick-reference.md references/WORKFLOW.md references/tooling.md references/codex-cli.md references/examples.md`

## AI Assistance
- AI-assisted: yes (Codex CLI)
- Testing level: docs consistency verification
- I understand this code: yes
