### PR TITLE
docs: standardize /humanizer policy for user-facing copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,13 @@ Keep this file concise; move long examples and deep procedures to `README.md` an
 - Final report must summarize files changed, key diffs, and side effects.
 - Prefer inclusive language: allowlist/blocklist, primary/replica, main branch.
 
+## Humanized Communication Policy
+
+- For user-facing long-form writing (outreach copy, status updates, explanations, docs prose), run a humanization pass by default.
+- Preferred invocation in OpenClaw contexts: `/humanizer`.
+- Keep exact technical artifacts untouched: code blocks, CLI commands, JSON/YAML payloads, IDs/UUIDs, URLs, stack traces, legal/compliance text, and direct quotations.
+- If humanizer is unavailable, continue safely with original text and note the fallback.
+
 ## OpenClaw Skill Notes
 
 - Keep `SKILL.md` AgentSkills-compatible: clear `name` + `description`, concise body, references for deep detail.

--- a/SKILL.md
+++ b/SKILL.md
@@ -126,6 +126,13 @@ Read these before doing any work:
 - `references/templates/plan-template.md` for plan artifact structure
 - `references/frontend-design.md` for frontend-design-ultimate source refs
 
+## Humanizer Usage (User-Facing Copy)
+
+For user-facing long-form text (status updates, outreach copy, explanatory prose), default to a humanization pass:
+- Preferred command: `/humanizer`
+- Keep exact technical artifacts unchanged (commands, code, IDs, links, payloads, legal text).
+- If unavailable, fall back to original text and proceed.
+
 ## Persona
 
 You are Dev: pragmatic, experienced, and direct. Explain tradeoffs and risks. Prefer simple, working solutions.

--- a/references/quick-reference.md
+++ b/references/quick-reference.md
@@ -150,6 +150,7 @@ Before marking ANY task complete:
 - [ ] Review audit completed?
 - [ ] PR body includes `What`, `Why`, `Tests`, `AI Assistance`?
 - [ ] Issue/PR title follows repo conventions?
+- [ ] User-facing long-form text passed through `/humanizer` (or fallback explicitly noted)?
 
 **Unchecked box = Task NOT complete.**
 


### PR DESCRIPTION
## What
- add Humanized Communication policy in 
- add  usage guidance in 
- extend pre-completion checklist to require humanizer pass (or explicit fallback note) for user-facing long-form text

## Why
- ensure consistent, human-readable communication quality across agents using this shared skill
- keep technical artifacts exact while improving non-technical prose

## Tests
- docs-only change

## AI Assistance
- AI-assisted: yes
- Testing level: docs-only verification
- I understand this code: yes
