### PR TITLE
docs(review): add PR intake + focus checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ These aliases are routing hints at the channel layer. Behavior is enforced by sk
 - `APPROVE` applies only to the latest plan in the **current conversation context**.
 - Approval is not global, does not carry across unrelated threads/chats, and does not auto-approve future plans.
 - If no pending plan exists in context, return: `No pending plan found. Run /plan first.`
+- Plan approval is text-gated via `APPROVE`; this workflow does not require a separate "ExitPlanMode" tool.
 
 ## OpenClaw Setup: Add Coding Skill Slash Commands
 

--- a/references/WORKFLOW.md
+++ b/references/WORKFLOW.md
@@ -31,6 +31,7 @@ These aliases do not change core policy:
 - Plan-first for non-trivial work
 - Explicit approval gate before writes
 - No bypass-by-default flags unless the user explicitly requests bypass.
+- Plan completion is approved through explicit `APPROVE` reply (there is no separate `ExitPlanMode` tool call in this repo flow).
 
 ## Git Workflow
 

--- a/references/quick-reference.md
+++ b/references/quick-reference.md
@@ -205,6 +205,11 @@ cd /path/to/repo
 timeout 600s codex review --base <base> --title "Review PR #N"
 ```
 
+**PR Review config-safety trigger check:**
+```bash
+gh pr view <PR> --json files --jq '.files[].path'
+```
+
 ### Git Workflow
 ```bash
 # If no PR arg was provided, list and select one PR first
@@ -266,12 +271,29 @@ Definitions:
 - `VERIFIED`: command/example was executed in this session.
 - `UNVERIFIED`: command/example was not executed in this session.
 
+### Configuration Safety Checklist (`/review_pr`)
+
+Trigger when changed files include:
+- `.env`, `.env.*`
+- `*.yml`, `*.yaml`, `*.json`, `*.toml`, `*.ini`, `*.conf`, `*.properties`
+- `Dockerfile`, `docker-compose*`
+- `.github/workflows/*`
+- `config/`, `infra/`, `deploy/`, `k8s/`, `helm/`
+
+For each flagged config change, include:
+- Load-test evidence (or explicit "not tested")
+- Rollback method + expected rollback time
+- Monitoring signals/alerts
+- Dependency/limit interactions
+- Historical context (incidents or none known)
+
 ## Command Reference
 
 | Task | Command |
 |------|---------|
 | List PRs | `gh pr list --repo owner/repo` |
 | View PR | `gh pr view <PR> --json number,title,state` |
+| List PR files | `gh pr view <PR> --json files --jq '.files[].path'` |
 | Diff PR | `gh pr diff <PR> --repo owner/repo` |
 | Checkout PR | `gh pr checkout <PR>` |
 | Review PR | `timeout 600s codex review --base <base> --title "PR #N Review"` |

--- a/references/reviews.md
+++ b/references/reviews.md
@@ -29,10 +29,27 @@
 ## Review Focus Checklist (Required)
 
 - Code correctness
+- Architecture and dependency boundaries
 - Project conventions and style
 - Performance implications
 - Test coverage quality and gaps
 - Security considerations
+
+## Configuration Safety Review (Required When Triggered)
+
+Run a configuration safety section in the review output when the PR touches any of:
+- `.env`, `.env.*`
+- `*.yml`, `*.yaml`, `*.json`, `*.toml`, `*.ini`, `*.conf`, `*.properties`
+- `Dockerfile`, `docker-compose*`
+- `.github/workflows/*`
+- `config/`, `infra/`, `deploy/`, `k8s/`, `helm/`
+
+Treat numeric/config value changes as risky until justified. For each flagged config change, require:
+- Load-test evidence (or explicit "not tested")
+- Rollback method and expected rollback time
+- Monitoring signals/alerts to detect regressions
+- Dependency/limit interaction analysis (upstream/downstream/system caps)
+- Historical context (similar prior incidents or "none known")
 
 ## Review Output Contract (Required)
 
@@ -41,6 +58,7 @@
 - Include open questions/assumptions after findings.
 - Include a short PR overview after findings (what changed and why).
 - Include specific improvement suggestions and key risks.
+- When configuration safety is triggered, include a dedicated `Configuration Safety` subsection with evidence.
 - If command/docs examples were changed, label each as:
   - `VERIFIED` (executed) or
   - `UNVERIFIED` (not executed)
@@ -89,6 +107,9 @@ gh pr view <PR>
 
 # Inspect patch before review output
 gh pr diff <PR>
+
+# Optional: list changed file paths to detect config-safety trigger
+gh pr view <PR> --json files --jq '.files[].path'
 
 # Code review (direct CLI)
 timeout 600s codex review --base <base> --title "PR #N Review"

--- a/references/templates/plan-system-prompt.txt
+++ b/references/templates/plan-system-prompt.txt
@@ -7,6 +7,8 @@ CRITICAL CONSTRAINTS:
 4) Do NOT run git mutation commands (commit/push/merge/rebase/reset/checkout -b/cherry-pick).
 5) Do NOT claim work was implemented.
 6) If information is missing, state assumptions explicitly.
+7) Do NOT run file-mutation commands (`touch`, `mkdir`, `rm`, `mv`, `cp`, `sed -i`, redirection `>`/`>>`, heredocs that write files).
+8) Read-only shell usage is allowed for evidence gathering only (`ls`, `rg`, `cat`, `git status`, `git log`, `git diff`).
 
 OUTPUT CONTRACT:
 - Return ONLY markdown.
@@ -68,5 +70,6 @@ Reply with one:
 QUALITY BAR:
 - Evidence must reference real files/commands (or explicitly say “not verified”).
 - Step list must be actionable and sequenced.
+- Include a "Critical files for implementation" list (3-5 files with one-line reason each) inside the plan body.
 - Test plan must be executable.
 - If task is trivial, still fill all sections; mark Fast-Path Eligible: yes.

--- a/skills/plan-issue/SKILL.md
+++ b/skills/plan-issue/SKILL.md
@@ -12,6 +12,21 @@ metadata: {"openclaw":{"emoji":"🧭"}}
 - The user asks for scope, sequencing, risks, or rollout strategy.
 - The task is non-trivial and would change files, infra, or workflows.
 
+### Proactive Trigger Matrix
+
+Use `/plan` proactively when any of these apply:
+- New feature implementation with non-obvious design choices.
+- Multiple valid approaches exist and tradeoff selection matters.
+- Changes are likely to touch more than 2-3 files.
+- Existing behavior/architecture will change.
+- Requirements are partially unclear and need repo exploration first.
+- User preference materially affects implementation direction.
+
+Skip `/plan` for:
+- Trivial typo or obvious one-line fixes.
+- Small deterministic edits with no architectural impact.
+- Pure information lookup requests (no implementation intent).
+
 ## Required Workflow
 
 1. Gather context using read-only operations first.


### PR DESCRIPTION
## What
- Added PR intake flow in `references/reviews.md` for `/review_pr` (`gh pr list`, `gh pr view`, `gh pr diff`).
- Added required review dimensions including architecture and explicit configuration safety expectations.
- Added deterministic config-safety trigger patterns and required evidence/questions for flagged config changes.
- Added quick-reference commands/checklist for config-safety detection and PR file listing.
- Added proactive `/plan` trigger matrix in `skills/plan-issue/SKILL.md`.
- Strengthened read-only constraints in `references/templates/plan-system-prompt.txt` while preserving the existing heading schema.
- Added explicit parity note that this repo uses `APPROVE` text gating (no separate ExitPlanMode tool semantics).

## Why
- Standardizes plan and review behavior around deterministic, auditable rules.
- Improves outage prevention by treating configuration changes as high-risk until justified.
- Keeps command surface stable (`/plan`, `/plan-review`, `/review_pr`) while improving depth and consistency.

## Tests
- `./scripts/doctor`
- `./scripts/doc-drift-check`
- `git diff --check`
- `rg -n "Proactive Trigger Matrix|ExitPlanMode|Critical files for implementation|Configuration Safety Review|List PR files|Plan approval is text-gated" skills/plan-issue/SKILL.md references/templates/plan-system-prompt.txt references/reviews.md references/quick-reference.md references/WORKFLOW.md README.md`

## AI Assistance
- AI-assisted: yes (Codex)
- Testing level: lightly tested (doc/tooling validation)
- Prompt/session log: current Codex session
- I understand this code: yes
