### PR TITLE
fix(plan-review): support non-tty resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ CLI wrappers:
 # Review with interactive section checkpoints (Architecture -> Code Quality -> Tests -> Performance)
 ./scripts/plan-review-live --repo /path/to/repo
 
+# Non-TTY/chat-safe live review finalization (no interactive prompts)
+./scripts/plan-review-live --repo /path/to/repo --decisions "1A,2B,3A,4A" --blocking none
+# or
+./scripts/plan-review-live --repo /path/to/repo --resolve-file /path/to/decisions.json
+
 # Execute an approved plan artifact
 # Requires latest plan-review metadata to be ready unless --force is used.
 ./scripts/code-implement --plan /path/to/repo/.ai/plans/<plan>.md
@@ -55,7 +60,7 @@ These aliases are routing hints at the channel layer. Behavior is enforced by sk
 - `/coding` → compatibility entry skill (`SKILL.md`), routes plan-first + execution flow
 - `/plan <task>` → `skills/plan-issue/SKILL.md` (plan only, no writes)
 - `/plan-review [--plan <path>]` → batch plan review (single-pass full report, marks unresolved blocking decisions)
-- `/plan-review-live [--plan <path>]` → interactive review checkpoints, records decisions, sets readiness metadata for execution gate
+- `/plan-review-live [--plan <path>]` → interactive checkpoints in TTY; in non-TTY/chat use `--decisions/--blocking` or `--resolve-file` to finalize readiness metadata
 - `/review_pr <number|url>` → review workflow with standards checks via `references/reviews.md`
 
 ### Approval Semantics
@@ -85,6 +90,15 @@ To enable this skill’s aliases for your team, add these entries under
 ```
 
 If some commands already exist in your config, keep existing entries and append only missing new ones to avoid overriding other aliases.
+
+Example resolve file for non-TTY finalization:
+
+```json
+{
+  "resolved_decisions": ["1A", "2B", "3A", "4A"],
+  "blocking_decisions": []
+}
+```
 
 ## Requirements
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,7 @@
+# TODOs
+
+## PLAN_REVIEW_LIVE_ALLOW_NON_TTY deprecation check
+- What: Evaluate deprecating `PLAN_REVIEW_LIVE_ALLOW_NON_TTY` after one release cycle.
+- Why: `plan-review-live` now supports explicit non-TTY resolution inputs (`--resolve-file` or `--decisions/--blocking`) that are safer and more auditable.
+- Context: Added to close issue #30 (chat/non-TTY dead-end for `plan-review-live`).
+- Depends on/blocked by: One stable release cycle of smoke + real chat automation runs with the new non-TTY apply path.

--- a/references/WORKFLOW.md
+++ b/references/WORKFLOW.md
@@ -211,6 +211,10 @@ For non-trivial work, generate a plan artifact before implementation:
 ./scripts/plan --engine codex --repo /path/to/repo "Implement feature X"
 ./scripts/plan-review --repo /path/to/repo
 ./scripts/plan-review-live --repo /path/to/repo
+# Non-TTY/chat-safe finalization:
+./scripts/plan-review-live --repo /path/to/repo --decisions "1A,2B,3A,4A" --blocking none
+# Or:
+./scripts/plan-review-live --repo /path/to/repo --resolve-file /path/to/decisions.json
 ./scripts/code-implement --plan /path/to/repo/.ai/plans/<plan>.md
 ```
 

--- a/references/quick-reference.md
+++ b/references/quick-reference.md
@@ -122,6 +122,12 @@ claude --resume
 # Interactive section-by-section review with decision checkpoints
 ./scripts/plan-review-live --repo /path/to/repo
 
+# Non-TTY/chat-safe finalization (no interactive prompts)
+./scripts/plan-review-live --repo /path/to/repo --decisions "1A,2B,3A,4A" --blocking none
+
+# Resolve from machine-readable file
+./scripts/plan-review-live --repo /path/to/repo --resolve-file /path/to/decisions.json
+
 # Execute approved plan (prompts for approval if still PENDING)
 # Requires latest plan-review metadata to be ready unless --force is used.
 ./scripts/code-implement --plan /path/to/repo/.ai/plans/<plan>.md
@@ -175,7 +181,7 @@ Before marking ANY task complete:
 
 ### Activate
 Use `/coding` in OpenClaw to activate this skill.
-For plan-first flow, use `/plan <task>` (maps to `scripts/plan`), `/plan-review` (batch), and `/plan-review-live` (interactive checkpoints).
+For plan-first flow, use `/plan <task>` (maps to `scripts/plan`), `/plan-review` (batch), and `/plan-review-live` (interactive in TTY; pass `--decisions/--blocking` or `--resolve-file` in non-TTY chat flows).
 
 ### Agent CLI Commands
 

--- a/scripts/code-plan-review
+++ b/scripts/code-plan-review
@@ -10,7 +10,7 @@ SYSTEM_PROMPT_FILE="$ROOT_DIR/references/templates/plan-review-system-prompt.txt
 usage() {
   cat >&2 <<'USAGE'
 Usage:
-  code-plan-review [--repo <path>] [--base <branch>] [--plan <path>] [--model <name>] [--output <path>] [--mode <batch|live>]
+  code-plan-review [--repo <path>] [--base <branch>] [--plan <path>] [--model <name>] [--output <path>] [--mode <batch|live|apply>] [--resolve-file <path>] [--decisions <csv>] [--blocking <csv|none>] [--non-tty <auto|error>]
 
 Defaults:
   --repo   current working directory
@@ -18,6 +18,7 @@ Defaults:
   --plan   latest generated .ai/plans/*.md (timestamped filename)
   --output .ai/plan-reviews/<timestamp>-<plan-id>.md
   --mode   batch
+  --non-tty auto
 USAGE
 }
 
@@ -27,6 +28,10 @@ PLAN_PATH=""
 MODEL=""
 OUTPUT_PATH=""
 MODE="batch"
+RESOLVE_FILE_PATH=""
+DECISIONS_INPUT=""
+BLOCKING_INPUT=""
+NON_TTY_MODE="auto"
 SECTION_TIMEOUT="${PLAN_REVIEW_LIVE_SECTION_TIMEOUT:-600}"
 TOTAL_TIMEOUT="${PLAN_REVIEW_LIVE_TOTAL_TIMEOUT:-2400}"
 ALLOW_NON_TTY="${PLAN_REVIEW_LIVE_ALLOW_NON_TTY:-0}"
@@ -60,6 +65,22 @@ while [[ $# -gt 0 ]]; do
       MODE="${2:-}"
       shift 2
       ;;
+    --resolve-file)
+      RESOLVE_FILE_PATH="${2:-}"
+      shift 2
+      ;;
+    --decisions)
+      DECISIONS_INPUT="${2:-}"
+      shift 2
+      ;;
+    --blocking)
+      BLOCKING_INPUT="${2:-}"
+      shift 2
+      ;;
+    --non-tty)
+      NON_TTY_MODE="${2:-}"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -72,8 +93,18 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ "$MODE" != "batch" && "$MODE" != "live" ]]; then
-  echo "Error: --mode must be batch or live" >&2
+if [[ "$MODE" != "batch" && "$MODE" != "live" && "$MODE" != "apply" ]]; then
+  echo "Error: --mode must be batch, live, or apply" >&2
+  exit 1
+fi
+
+if [[ "$NON_TTY_MODE" != "auto" && "$NON_TTY_MODE" != "error" ]]; then
+  echo "Error: --non-tty must be auto or error" >&2
+  exit 1
+fi
+
+if [[ -n "$RESOLVE_FILE_PATH" && ( -n "$DECISIONS_INPUT" || -n "$BLOCKING_INPUT" ) ]]; then
+  echo "Error: --resolve-file cannot be combined with --decisions or --blocking." >&2
   exit 1
 fi
 
@@ -242,6 +273,106 @@ json_array_from_file() {
   printf ']'
 }
 
+has_resolution_inputs() {
+  if [[ -n "$RESOLVE_FILE_PATH" || -n "$DECISIONS_INPUT" || -n "$BLOCKING_INPUT" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+resolution_usage_hint() {
+  cat >&2 <<'EOF'
+Examples:
+  ./scripts/plan-review-live --repo /path/to/repo --decisions "1A,2B,3A,4A" --blocking none
+  ./scripts/plan-review-live --repo /path/to/repo --resolve-file /path/to/decisions.json
+EOF
+}
+
+parse_resolution_file() {
+  local source_path="$1"
+  local resolved_out="$2"
+  local blocking_out="$3"
+  local abs_path="$source_path"
+
+  if [[ "$abs_path" != /* ]]; then
+    abs_path="$REPO_PATH/$abs_path"
+  fi
+  if [[ ! -f "$abs_path" ]]; then
+    echo "Error: --resolve-file not found: $abs_path" >&2
+    exit 1
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "Error: python3 is required to parse --resolve-file JSON input." >&2
+    exit 1
+  fi
+
+  if ! python3 - "$abs_path" "$resolved_out" "$blocking_out" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+resolve_path = Path(sys.argv[1])
+resolved_out = Path(sys.argv[2])
+blocking_out = Path(sys.argv[3])
+
+try:
+    payload = json.loads(resolve_path.read_text(encoding="utf-8"))
+except Exception as exc:
+    print(f"Error: invalid resolve file JSON: {exc}", file=sys.stderr)
+    raise SystemExit(1)
+
+if not isinstance(payload, dict):
+    print("Error: resolve file must be a JSON object.", file=sys.stderr)
+    raise SystemExit(1)
+
+for key in ("resolved_decisions", "blocking_decisions"):
+    if key not in payload:
+        print(f"Error: resolve file missing required key '{key}'.", file=sys.stderr)
+        raise SystemExit(1)
+    if not isinstance(payload[key], list):
+        print(f"Error: resolve file key '{key}' must be an array of strings.", file=sys.stderr)
+        raise SystemExit(1)
+
+def normalize(values, key_name):
+    normalized = []
+    for idx, value in enumerate(values):
+        if not isinstance(value, str):
+            print(
+                f"Error: resolve file key '{key_name}' contains non-string entry at index {idx}.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        trimmed = value.strip()
+        if not trimmed:
+            continue
+        if trimmed.lower() == "none":
+            continue
+        normalized.append(trimmed)
+    return normalized
+
+resolved = normalize(payload["resolved_decisions"], "resolved_decisions")
+blocking = normalize(payload["blocking_decisions"], "blocking_decisions")
+
+resolved_out.write_text("".join(f"{item}\n" for item in resolved), encoding="utf-8")
+blocking_out.write_text("".join(f"{item}\n" for item in blocking), encoding="utf-8")
+PY
+  then
+    exit 1
+  fi
+}
+
+load_resolution_inputs() {
+  : > "$RESOLVED_FILE"
+  : > "$BLOCKING_FILE"
+
+  if [[ -n "$RESOLVE_FILE_PATH" ]]; then
+    parse_resolution_file "$RESOLVE_FILE_PATH" "$RESOLVED_FILE" "$BLOCKING_FILE"
+  else
+    append_list_entries "$DECISIONS_INPUT" "$RESOLVED_FILE"
+    append_list_entries "$BLOCKING_INPUT" "$BLOCKING_FILE"
+  fi
+}
+
 write_metadata() {
   local ready="$1"
   local history_path
@@ -399,23 +530,81 @@ $(cat "$PLAN_PATH")
 EOF
 
   run_codex_prompt "$(cat "$SYSTEM_PROMPT")" | tee "$TMP_OUTPUT"
-  printf '%s\n' "Run ./scripts/plan-review-live to resolve interactive decisions" >> "$BLOCKING_FILE"
-  write_metadata "false"
+  if has_resolution_inputs; then
+    load_resolution_inputs
+    dedupe_file "$BLOCKING_FILE"
+    if [[ -s "$BLOCKING_FILE" ]]; then
+      write_metadata "false"
+    else
+      write_metadata "true"
+    fi
+  else
+    printf '%s\n' "Run ./scripts/plan-review-live to resolve interactive decisions" >> "$BLOCKING_FILE"
+    write_metadata "false"
+  fi
+elif [[ "$MODE" == "apply" ]]; then
+  if ! has_resolution_inputs; then
+    echo "Error: apply mode requires --resolve-file or --decisions/--blocking." >&2
+    resolution_usage_hint
+    exit 1
+  fi
+  load_resolution_inputs
+  {
+    echo "# Plan Review (Applied Decisions)"
+    echo
+    echo "- Plan: $PLAN_PATH"
+    echo "- Mode: apply"
+    echo "- Applied at: $CREATED_AT"
+    echo
+  } > "$TMP_OUTPUT"
+  dedupe_file "$BLOCKING_FILE"
+  if [[ -s "$BLOCKING_FILE" ]]; then
+    write_metadata "false"
+  else
+    write_metadata "true"
+  fi
 else
+  non_tty=0
   if [[ ! -t 0 || ! -t 1 ]]; then
+    non_tty=1
+  fi
+
+  if (( non_tty == 1 )); then
     if [[ "$ALLOW_NON_TTY" == "1" ]]; then
       echo "Warning: PLAN_REVIEW_LIVE_ALLOW_NON_TTY=1 set; bypassing TTY requirement for live mode." >&2
+    elif [[ "$NON_TTY_MODE" == "error" ]]; then
+      echo "Error: live mode requires an interactive terminal (TTY)." >&2
+      resolution_usage_hint
+      exit 1
+    elif has_resolution_inputs; then
+      load_resolution_inputs
+      {
+        echo "# Plan Review (Live Auto-Fallback)"
+        echo
+        echo "- Plan: $PLAN_PATH"
+        echo "- Mode: live (non-tty auto-apply)"
+        echo "- Applied at: $CREATED_AT"
+        echo
+      } > "$TMP_OUTPUT"
+      dedupe_file "$BLOCKING_FILE"
+      if [[ -s "$BLOCKING_FILE" ]]; then
+        write_metadata "false"
+      else
+        write_metadata "true"
+      fi
     else
-      echo "Error: live mode requires an interactive terminal (TTY). Use scripts/plan-review for batch mode." >&2
+      echo "Error: non-TTY live mode requires decision input. Use --resolve-file or --decisions/--blocking." >&2
+      resolution_usage_hint
       exit 1
     fi
   fi
 
-  START_TS="$(date +%s)"
-  PLAN_CONTEXT_FILE="$TMP_DIR/plan-context.txt"
-  build_live_plan_context "$PLAN_CONTEXT_FILE"
+  if (( non_tty == 0 || ALLOW_NON_TTY == 1 )); then
+    START_TS="$(date +%s)"
+    PLAN_CONTEXT_FILE="$TMP_DIR/plan-context.txt"
+    build_live_plan_context "$PLAN_CONTEXT_FILE"
 
-  cat > "$TMP_OUTPUT" <<EOF
+    cat > "$TMP_OUTPUT" <<EOF
 # Plan Review (Live)
 
 - Plan: $PLAN_PATH
@@ -423,42 +612,42 @@ else
 - Started at: $CREATED_AT
 
 EOF
-  cp "$TMP_OUTPUT" "$OUTPUT_PATH"
-  printf '%s\n' "$LIVE_INCOMPLETE_MARKER" >> "$BLOCKING_FILE"
-  write_metadata "false"
+    cp "$TMP_OUTPUT" "$OUTPUT_PATH"
+    printf '%s\n' "$LIVE_INCOMPLETE_MARKER" >> "$BLOCKING_FILE"
+    write_metadata "false"
 
-  section_names=(
-    "Architecture"
-    "Code Quality"
-    "Tests"
-    "Performance"
-  )
+    section_names=(
+      "Architecture"
+      "Code Quality"
+      "Tests"
+      "Performance"
+    )
 
-  section_instructions=(
-    "Run only Architecture review. Identify up to 4 top issues with options and explicit recommendation. End by asking for decision labels."
-    "Run only Code Quality review. Identify up to 4 top issues with options and explicit recommendation. End by asking for decision labels."
-    "Run only Test review. Include ASCII test diagram and coverage/eval gaps. End by asking for decision labels."
-    "Run only Performance review. Identify up to 4 top issues with options and explicit recommendation. End by asking for decision labels."
-  )
+    section_instructions=(
+      "Run only Architecture review. Identify up to 4 top issues with options and explicit recommendation. End by asking for decision labels."
+      "Run only Code Quality review. Identify up to 4 top issues with options and explicit recommendation. End by asking for decision labels."
+      "Run only Test review. Include ASCII test diagram and coverage/eval gaps. End by asking for decision labels."
+      "Run only Performance review. Identify up to 4 top issues with options and explicit recommendation. End by asking for decision labels."
+    )
 
-  for idx in "${!section_names[@]}"; do
-    now_ts="$(date +%s)"
-    elapsed=$((now_ts - START_TS))
-    remaining=$((TOTAL_TIMEOUT - elapsed))
-    if (( remaining <= 0 )); then
-      echo "Error: live review exceeded total timeout budget (${TOTAL_TIMEOUT}s)." >&2
-      exit 1
-    fi
-    effective_timeout="$SECTION_TIMEOUT"
-    if (( remaining < SECTION_TIMEOUT )); then
-      effective_timeout="$remaining"
-    fi
+    for idx in "${!section_names[@]}"; do
+      now_ts="$(date +%s)"
+      elapsed=$((now_ts - START_TS))
+      remaining=$((TOTAL_TIMEOUT - elapsed))
+      if (( remaining <= 0 )); then
+        echo "Error: live review exceeded total timeout budget (${TOTAL_TIMEOUT}s)." >&2
+        exit 1
+      fi
+      effective_timeout="$SECTION_TIMEOUT"
+      if (( remaining < SECTION_TIMEOUT )); then
+        effective_timeout="$remaining"
+      fi
 
-    section_name="${section_names[$idx]}"
-    section_instruction="${section_instructions[$idx]}"
+      section_name="${section_names[$idx]}"
+      section_instruction="${section_instructions[$idx]}"
 
-    cat "$SYSTEM_PROMPT_FILE" > "$SYSTEM_PROMPT"
-    cat >> "$SYSTEM_PROMPT" <<EOF
+      cat "$SYSTEM_PROMPT_FILE" > "$SYSTEM_PROMPT"
+      cat >> "$SYSTEM_PROMPT" <<EOF
 
 TASK CONTEXT:
 - Repository: $REPO_PATH
@@ -480,32 +669,33 @@ SHARED PLAN CONTEXT:
 $(cat "$PLAN_CONTEXT_FILE")
 EOF
 
-    section_output="$(run_codex_prompt "$(cat "$SYSTEM_PROMPT")" "$effective_timeout")"
-    {
-      echo
-      echo "## $section_name"
-      echo
-      echo "$section_output"
-      echo
-    } >> "$TMP_OUTPUT"
+      section_output="$(run_codex_prompt "$(cat "$SYSTEM_PROMPT")" "$effective_timeout")"
+      {
+        echo
+        echo "## $section_name"
+        echo
+        echo "$section_output"
+        echo
+      } >> "$TMP_OUTPUT"
 
-    echo "[$section_name] Enter selected decision labels (comma-separated, or none):" >&2
-    read -r selected_input
-    append_list_entries "$selected_input" "$RESOLVED_FILE"
+      echo "[$section_name] Enter selected decision labels (comma-separated, or none):" >&2
+      read -r selected_input
+      append_list_entries "$selected_input" "$RESOLVED_FILE"
 
-    echo "[$section_name] Enter unresolved blocking decision IDs/descriptions (comma-separated, or none):" >&2
-    read -r blocking_input
-    append_list_entries "$blocking_input" "$BLOCKING_FILE"
-  done
+      echo "[$section_name] Enter unresolved blocking decision IDs/descriptions (comma-separated, or none):" >&2
+      read -r blocking_input
+      append_list_entries "$blocking_input" "$BLOCKING_FILE"
+    done
 
-  tmp_filtered="$(mktemp)"
-  grep -Fxv "$LIVE_INCOMPLETE_MARKER" "$BLOCKING_FILE" > "$tmp_filtered" || true
-  mv "$tmp_filtered" "$BLOCKING_FILE"
-  dedupe_file "$BLOCKING_FILE"
-  if [[ -s "$BLOCKING_FILE" ]]; then
-    write_metadata "false"
-  else
-    write_metadata "true"
+    tmp_filtered="$(mktemp)"
+    grep -Fxv "$LIVE_INCOMPLETE_MARKER" "$BLOCKING_FILE" > "$tmp_filtered" || true
+    mv "$tmp_filtered" "$BLOCKING_FILE"
+    dedupe_file "$BLOCKING_FILE"
+    if [[ -s "$BLOCKING_FILE" ]]; then
+      write_metadata "false"
+    else
+      write_metadata "true"
+    fi
   fi
 fi
 

--- a/scripts/smoke-wrappers.sh
+++ b/scripts/smoke-wrappers.sh
@@ -409,6 +409,199 @@ EOF
   assert_contains "$codex_args" "LIVE REVIEW SECTION: Performance"
 }
 
+test_plan_review_live_non_tty_auto_apply_with_flags() {
+  local repo="$tmp_dir/repo-plan-review-live-auto-flags"
+  local output_file="$repo/.ai/plan-reviews/live-auto-flags.md"
+  mkdir -p "$repo/.ai/plans"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email smoke@example.com
+  git -C "$repo" config user.name smoke
+  echo "hi" > "$repo/README.md"
+  git -C "$repo" add README.md
+  git -C "$repo" commit -q -m "init"
+
+  cat > "$repo/.ai/plans/2026-02-19-000005-live-auto.md" <<'EOF'
+---
+id: 2026-02-19-000005-live-auto
+status: APPROVED
+---
+
+# Plan: Live Auto
+EOF
+
+  PATH="$fake_bin:$PATH" \
+    "$SCRIPT_DIR/plan-review-live" --repo "$repo" --plan "$repo/.ai/plans/2026-02-19-000005-live-auto.md" --decisions "1A,2A,3A,4A" --blocking none --output "$output_file" > "$tmp_dir/plan-review-live-auto-flags.out"
+
+  [[ -f "$output_file" ]] || { echo "Expected non-tty auto-apply output markdown" >&2; exit 1; }
+  assert_contains "$output_file" "Mode: live (non-tty auto-apply)"
+
+  local latest_metadata="$repo/.ai/plan-reviews/latest-2026-02-19-000005-live-auto.json"
+  [[ -f "$latest_metadata" ]] || { echo "Expected latest metadata for non-tty auto-apply" >&2; exit 1; }
+  assert_contains "$latest_metadata" "\"ready_for_implementation\": true"
+  assert_contains "$latest_metadata" "\"blocking_decisions\": []"
+  assert_contains "$latest_metadata" "\"resolved_decisions\": [\"1A\", \"2A\", \"3A\", \"4A\"]"
+}
+
+test_plan_review_live_non_tty_auto_apply_with_resolve_file() {
+  local repo="$tmp_dir/repo-plan-review-live-auto-file"
+  local output_file="$repo/.ai/plan-reviews/live-auto-file.md"
+  local resolve_file="$tmp_dir/resolve-file.json"
+  mkdir -p "$repo/.ai/plans"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email smoke@example.com
+  git -C "$repo" config user.name smoke
+  echo "hi" > "$repo/README.md"
+  git -C "$repo" add README.md
+  git -C "$repo" commit -q -m "init"
+
+  cat > "$repo/.ai/plans/2026-02-19-000006-live-auto.md" <<'EOF'
+---
+id: 2026-02-19-000006-live-auto
+status: APPROVED
+---
+
+# Plan: Live Auto File
+EOF
+
+  cat > "$resolve_file" <<'EOF'
+{
+  "resolved_decisions": ["1A", "1A", "none", "2A", "3A", "4A"],
+  "blocking_decisions": ["none"]
+}
+EOF
+
+  PATH="$fake_bin:$PATH" \
+    "$SCRIPT_DIR/plan-review-live" --repo "$repo" --plan "$repo/.ai/plans/2026-02-19-000006-live-auto.md" --resolve-file "$resolve_file" --output "$output_file" > "$tmp_dir/plan-review-live-auto-file.out"
+
+  [[ -f "$output_file" ]] || { echo "Expected non-tty auto-apply output markdown (resolve file)" >&2; exit 1; }
+  assert_contains "$output_file" "Mode: live (non-tty auto-apply)"
+
+  local latest_metadata="$repo/.ai/plan-reviews/latest-2026-02-19-000006-live-auto.json"
+  [[ -f "$latest_metadata" ]] || { echo "Expected latest metadata for resolve-file auto-apply" >&2; exit 1; }
+  assert_contains "$latest_metadata" "\"ready_for_implementation\": true"
+  assert_contains "$latest_metadata" "\"blocking_decisions\": []"
+  assert_contains "$latest_metadata" "\"resolved_decisions\": [\"1A\", \"2A\", \"3A\", \"4A\"]"
+}
+
+test_plan_review_live_rejects_mixed_resolution_inputs() {
+  local repo="$tmp_dir/repo-plan-review-live-mixed-inputs"
+  local resolve_file="$tmp_dir/resolve-mixed-inputs.json"
+  mkdir -p "$repo/.ai/plans"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email smoke@example.com
+  git -C "$repo" config user.name smoke
+  echo "hi" > "$repo/README.md"
+  git -C "$repo" add README.md
+  git -C "$repo" commit -q -m "init"
+
+  cat > "$repo/.ai/plans/2026-02-19-000009-live-mixed.md" <<'EOF'
+---
+id: 2026-02-19-000009-live-mixed
+status: APPROVED
+---
+
+# Plan: Live Mixed
+EOF
+
+  cat > "$resolve_file" <<'EOF'
+{
+  "resolved_decisions": ["1A"],
+  "blocking_decisions": []
+}
+EOF
+
+  local output="$tmp_dir/plan-review-live-mixed-inputs.out"
+  if PATH="$fake_bin:$PATH" "$SCRIPT_DIR/plan-review-live" --repo "$repo" --plan "$repo/.ai/plans/2026-02-19-000009-live-mixed.md" --resolve-file "$resolve_file" --decisions "2B" > "$output" 2>&1; then
+    echo "Expected mixed resolution inputs to fail" >&2
+    exit 1
+  fi
+  assert_contains "$output" "--resolve-file cannot be combined"
+}
+
+test_plan_review_live_non_tty_requires_resolution_inputs() {
+  local repo="$tmp_dir/repo-plan-review-live-no-inputs"
+  mkdir -p "$repo/.ai/plans"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email smoke@example.com
+  git -C "$repo" config user.name smoke
+  echo "hi" > "$repo/README.md"
+  git -C "$repo" add README.md
+  git -C "$repo" commit -q -m "init"
+
+  cat > "$repo/.ai/plans/2026-02-19-000007-live-no-input.md" <<'EOF'
+---
+id: 2026-02-19-000007-live-no-input
+status: APPROVED
+---
+
+# Plan: Live No Inputs
+EOF
+
+  local output="$tmp_dir/plan-review-live-no-inputs.out"
+  if PATH="$fake_bin:$PATH" "$SCRIPT_DIR/plan-review-live" --repo "$repo" --plan "$repo/.ai/plans/2026-02-19-000007-live-no-input.md" > "$output" 2>&1; then
+    echo "Expected plan-review-live to fail in non-tty mode without decision inputs" >&2
+    exit 1
+  fi
+  assert_contains "$output" "non-TTY live mode requires decision input"
+  assert_contains "$output" "--resolve-file"
+}
+
+test_plan_review_live_rejects_invalid_resolve_file() {
+  local repo="$tmp_dir/repo-plan-review-live-invalid-resolve"
+  mkdir -p "$repo/.ai/plans"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email smoke@example.com
+  git -C "$repo" config user.name smoke
+  echo "hi" > "$repo/README.md"
+  git -C "$repo" add README.md
+  git -C "$repo" commit -q -m "init"
+
+  cat > "$repo/.ai/plans/2026-02-19-000008-live-invalid.md" <<'EOF'
+---
+id: 2026-02-19-000008-live-invalid
+status: APPROVED
+---
+
+# Plan: Live Invalid
+EOF
+
+  local invalid_json="$tmp_dir/resolve-invalid-json.json"
+  local missing_key="$tmp_dir/resolve-missing-key.json"
+  local wrong_type="$tmp_dir/resolve-wrong-type.json"
+
+  printf '{' > "$invalid_json"
+  cat > "$missing_key" <<'EOF'
+{"resolved_decisions": ["1A"]}
+EOF
+  cat > "$wrong_type" <<'EOF'
+{
+  "resolved_decisions": ["1A", 2],
+  "blocking_decisions": []
+}
+EOF
+
+  local output_json="$tmp_dir/plan-review-live-invalid-json.out"
+  if PATH="$fake_bin:$PATH" "$SCRIPT_DIR/plan-review-live" --repo "$repo" --plan "$repo/.ai/plans/2026-02-19-000008-live-invalid.md" --resolve-file "$invalid_json" > "$output_json" 2>&1; then
+    echo "Expected invalid JSON resolve-file to fail" >&2
+    exit 1
+  fi
+  assert_contains "$output_json" "invalid resolve file JSON"
+
+  local output_missing="$tmp_dir/plan-review-live-missing-key.out"
+  if PATH="$fake_bin:$PATH" "$SCRIPT_DIR/plan-review-live" --repo "$repo" --plan "$repo/.ai/plans/2026-02-19-000008-live-invalid.md" --resolve-file "$missing_key" > "$output_missing" 2>&1; then
+    echo "Expected missing-key resolve-file to fail" >&2
+    exit 1
+  fi
+  assert_contains "$output_missing" "missing required key 'blocking_decisions'"
+
+  local output_type="$tmp_dir/plan-review-live-wrong-type.out"
+  if PATH="$fake_bin:$PATH" "$SCRIPT_DIR/plan-review-live" --repo "$repo" --plan "$repo/.ai/plans/2026-02-19-000008-live-invalid.md" --resolve-file "$wrong_type" > "$output_type" 2>&1; then
+    echo "Expected wrong-type resolve-file to fail" >&2
+    exit 1
+  fi
+  assert_contains "$output_type" "contains non-string entry"
+}
+
 create_approved_plan() {
   local repo="$1"
   local plan_id="$2"
@@ -599,6 +792,31 @@ test_code_implement_force_bypasses_review_gate() {
   assert_contains "$output" "Failed to create tmux session"
 }
 
+test_code_implement_accepts_metadata_from_non_tty_apply_flow() {
+  local repo="$tmp_dir/repo-code-implement-from-auto-apply"
+  mkdir -p "$repo/.ai/plans"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email smoke@example.com
+  git -C "$repo" config user.name smoke
+  echo "hi" > "$repo/README.md"
+  git -C "$repo" add README.md
+  git -C "$repo" commit -q -m "init"
+
+  local plan_path
+  plan_path="$(create_approved_plan "$repo" "2026-02-19-000015-auto-apply-gate")"
+  PATH="$fake_bin:$PATH" \
+    "$SCRIPT_DIR/plan-review-live" --repo "$repo" --plan "$plan_path" --decisions "1A,2A,3A,4A" --blocking none > "$tmp_dir/plan-review-live-gate.out"
+
+  local output="$tmp_dir/code-implement-auto-apply-gate.out"
+  if (cd "$repo" && PATH="$fake_bin:$PATH" "$SCRIPT_DIR/code-implement" --plan "$plan_path" > "$output" 2>&1); then
+    echo "Expected code-implement to fail later due tmux in smoke environment" >&2
+    exit 1
+  fi
+
+  assert_not_contains "$output" "review gate blocked implementation"
+  assert_contains "$output" "Failed to create tmux session"
+}
+
 test_invalid_mode_rejected
 test_invalid_cli_rejected
 test_review_prompt_pass_through
@@ -609,10 +827,16 @@ test_safe_impl_claude_plan_mode_no_dangerous_skip
 test_plan_review_generates_artifact
 test_plan_review_output_parent_dirs_created
 test_plan_review_live_generates_ready_metadata
+test_plan_review_live_non_tty_auto_apply_with_flags
+test_plan_review_live_non_tty_auto_apply_with_resolve_file
+test_plan_review_live_non_tty_requires_resolution_inputs
+test_plan_review_live_rejects_invalid_resolve_file
+test_plan_review_live_rejects_mixed_resolution_inputs
 test_code_implement_blocks_when_metadata_missing
 test_code_implement_blocks_when_metadata_invalid
 test_code_implement_blocks_when_unresolved_blockers_exist
 test_code_implement_allows_ready_metadata
 test_code_implement_force_bypasses_review_gate
+test_code_implement_accepts_metadata_from_non_tty_apply_flow
 
 printf 'Wrapper smoke tests passed.\n'


### PR DESCRIPTION
## What
- Add non-interactive decision resolution inputs to `scripts/code-plan-review`:
  - `--resolve-file <path>`
  - `--decisions <csv>`
  - `--blocking <csv|none>`
  - `--non-tty <auto|error>`
  - `--mode apply`
- Implement a canonical resolution parser path and strict validation:
  - reject mixed `--resolve-file` + flag inputs
  - validate resolve-file JSON shape (`resolved_decisions` + `blocking_decisions` arrays of strings)
- Add non-TTY live-mode auto-fallback behavior:
  - non-TTY + resolution input => apply decisions and write final metadata
  - non-TTY + no resolution input => fail fast with actionable guidance
- Keep `PLAN_REVIEW_LIVE_ALLOW_NON_TTY` compatibility path, but de-emphasize in docs.
- Extend smoke coverage for non-TTY success/failure scenarios and code-implement gate integration.
- Update docs (`README.md`, `references/WORKFLOW.md`, `references/quick-reference.md`) with chat-safe command examples.
- Add `TODOS.md` follow-up to evaluate deprecating `PLAN_REVIEW_LIVE_ALLOW_NON_TTY` after a release cycle.

## Why
Issue #30 reports that `plan-review-live` blocks in chat/non-TTY workflows and leaves `ready_for_implementation: false` with unresolved interactive blockers. This PR adds a non-interactive path so OpenClaw chat automation can finalize plan-review metadata without raw TTY prompts.

Closes #30.

## Tests
- `./scripts/smoke-wrappers.sh`
- `bash -n scripts/code-plan-review scripts/smoke-wrappers.sh`

## AI Assistance
- AI-assisted: yes (Codex CLI)
- Testing level: fully tested (targeted smoke + shell syntax checks)
- Prompt/session log: local Codex CLI session (no public log URL)
- I understand this code.
