### PR TITLE
feat(skill): add opt-in verbose progress mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,13 @@ Keep this file concise; move long examples and deep procedures to `README.md` an
 3. Get explicit `APPROVE` before file writes, package installs, or system changes.
 4. After approval, execute end-to-end and report progress, results, and deviations.
 
+### Verbosity Mode
+
+- `CODING_AGENT_VERBOSE` controls execution progress verbosity and is opt-in.
+- Default behavior is concise when the variable is unset or falsy.
+- When enabled, use `Now/Why/Next` progress updates for active execution.
+- Verbosity must never delay action once execution is approved and unblocked.
+
 ## Long-Running Commands
 
 - Ensure `tsx` scripts close watchers/timers and call `process.exit(0)`.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,33 @@ Example resolve file for non-TTY finalization:
 ./scripts/smoke-wrappers.sh
 ```
 
+## Verbosity Configuration
+
+The coding-agent skill supports an opt-in execution progress verbosity mode via
+`CODING_AGENT_VERBOSE`.
+
+- Default: off (concise updates)
+- On: structured progress updates (`Now`, `Why`, `Next`) during execution
+- Scope: progress updates only (not globally longer planning/review prose)
+
+Truthy values (case-insensitive): `1`, `true`, `on`, `yes`, `verbose`
+
+One-shot example:
+
+```bash
+CODING_AGENT_VERBOSE=1 ./scripts/code-implement --plan /path/to/repo/.ai/plans/<plan>.md
+```
+
+Persistent OpenClaw gateway setup:
+
+1. Add to `~/.config/systemd/user/secrets.conf`:
+   `CODING_AGENT_VERBOSE="1"`
+2. Reload the user unit:
+
+```bash
+systemctl --user daemon-reload && systemctl --user restart openclaw-gateway.service
+```
+
 ## CI Workflows
 
 - `wrapper-smoke.yml`: wrapper syntax, drift, and smoke validation.

--- a/THEORY.MD
+++ b/THEORY.MD
@@ -1,0 +1,49 @@
+# Theory: Opt-In Verbose Progress for Coding-Agent
+
+## Problem
+
+The skill currently has no explicit verbosity control, so users who want richer
+execution telemetry get inconsistent behavior. At the same time, this is a
+public/shared skill, so making all responses verbose by default would degrade
+the default experience for users who prefer concise output.
+
+## Operating Theory
+
+The right lever is an opt-in runtime switch, not another command alias. This
+skill already relies on environment-based behavior controls
+(`CODING_AGENT_IMPL_MODE`, `CODING_AGENT_CLAUDE_BIN`), and OpenClaw deploys
+through a systemd environment file. That makes environment configuration a
+stable, low-friction integration path that does not require command memorization
+or channel-specific command wiring.
+
+The value target is execution visibility, not longer prose everywhere. The
+highest impact behavior is to make progress reporting explicit (`Now`, `Why`,
+`Next`) during active execution while preserving concise defaults.
+
+## Strategy
+
+Define a single environment contract: `CODING_AGENT_VERBOSE`, default off.
+Document accepted truthy/falsy values so behavior is predictable and testable.
+Apply the mode to execution-progress updates only. Keep core guardrails and
+approval semantics unchanged to avoid coupling verbosity with workflow control.
+
+Expose the mode in three places:
+
+1. Skill behavior contract (`skills/coding-agent/SKILL.md`)
+2. Operator docs (`README.md`, `references/tooling.md`, `AGENTS.md`)
+3. Runtime diagnostics (`scripts/doctor`)
+
+Then mirror the same changes into the local installed skill path so live agent
+behavior matches the upstream repo state.
+
+## Key Discoveries
+
+The existing skill pack already has a clear environment-variable pattern and a
+doctor script that reports effective defaults. This avoids adding new command
+surface area and keeps rollout simple.
+
+## Open Questions
+
+Whether to add slash-command toggles later (`/verbose on|off`) remains optional.
+Current approach intentionally avoids that to keep configuration centralized and
+portable across channels.

--- a/references/tooling.md
+++ b/references/tooling.md
@@ -201,6 +201,7 @@ Cleanup:
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `CODING_AGENT_IMPL_MODE` | Implementation routing policy (`direct|tmux|auto`) | `direct` |
+| `CODING_AGENT_VERBOSE` | Execution progress verbosity (`off` by default; truthy: `1|true|on|yes|verbose`) | `off` |
 | `CODING_AGENT_CLAUDE_BIN` | Explicit Claude CLI path override | unset |
 | `OPENCLAW_TMUX_SOCKET_DIR` | Socket directory (preferred) | `${TMPDIR:-/tmp}/openclaw-tmux-sockets` |
 | `CLAWDBOT_TMUX_SOCKET_DIR` | Legacy socket directory | unset |

--- a/scripts/doctor
+++ b/scripts/doctor
@@ -47,6 +47,14 @@ fi
 
 printf '[info] implementation mode default: %s (set CODING_AGENT_IMPL_MODE=direct|tmux|auto to override)\n' "${CODING_AGENT_IMPL_MODE:-direct}"
 
+verbose_mode="off"
+case "${CODING_AGENT_VERBOSE:-}" in
+  1|[Tt][Rr][Uu][Ee]|[Oo][Nn]|[Yy][Ee][Ss]|[Vv][Ee][Rr][Bb][Oo][Ss][Ee])
+    verbose_mode="on"
+    ;;
+esac
+printf '[info] progress verbosity: %s (set CODING_AGENT_VERBOSE=1 to enable Now/Why/Next updates)\n' "$verbose_mode"
+
 if [[ "$failures" -gt 0 ]]; then
   printf '\nPreflight failed with %s issue(s).\n' "$failures" >&2
   exit 1

--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -31,6 +31,24 @@ If no matching approved plan exists, stop and request:
 - unit/integration/e2e tests as applicable
 5. Report exact commands run, outcomes, and residual risk.
 
+## Verbosity Mode (Progress Updates)
+
+`CODING_AGENT_VERBOSE` controls execution progress verbosity. Default is off.
+
+- `off` (default): concise progress updates.
+- `on`: include structured progress updates with `Now`, `Why`, and `Next`.
+
+Accepted truthy values (case-insensitive): `1`, `true`, `on`, `yes`, `verbose`.
+Accepted falsy values: unset, `0`, `false`, `off`, `no`.
+
+When verbose mode is on:
+- Send kickoff execution status in `Now/Why/Next` format.
+- For long-running tasks, send periodic status updates.
+- Send a completion update with outcome and blockers (if any).
+
+Verbosity must not block execution. After explaining intent, proceed immediately
+unless waiting on a required user decision or an explicit approval gate.
+
 ## Guardrails
 
 - No bypass-by-default. Do not use approval-bypass flags unless the user explicitly requests bypass.


### PR DESCRIPTION
## What
- add CODING_AGENT_VERBOSE as an opt-in execution progress verbosity toggle (default off)
- document behavior contract in skills/coding-agent/SKILL.md with truthy/falsy values and Now/Why/Next semantics
- add operator docs in README.md for one-shot and persistent systemd setup
- add policy guidance in AGENTS.md to keep default concise and ensure verbosity never blocks execution
- add variable to references/tooling.md environment table
- extend scripts/doctor to report effective progress verbosity mode
- add THEORY.MD narrative for the repository workstream

## Why
- users need richer runtime progress updates in some contexts
- default behavior must remain concise because this is a shared/public skill
- env-var config matches existing skill conventions (CODING_AGENT_IMPL_MODE) and systemd-based OpenClaw deployment

## Tests
- ./scripts/doctor
- ./scripts/smoke-wrappers.sh

## AI Assistance
- Used: yes (Codex CLI)
- Testing level: local wrapper preflight + smoke test suite
- Prompt/session log link: local Codex session (no shareable URL)
- I understand this code.

## Linked Issue
- Relates to #39
