### PR TITLE
fix(plan-review): address #54 follow-on review findings

### DIFF
--- a/scripts/code-implement
+++ b/scripts/code-implement
@@ -25,10 +25,10 @@ PLAN_PATH=""
 FORCE=0
 PROMPT=""
 EXEC_REPO="$(pwd)"
-NON_TTY=0
+NON_INTERACTIVE_STDIN=0
 
-if [[ ! -t 0 || ! -t 1 ]]; then
-  NON_TTY=1
+if [[ ! -t 0 ]]; then
+  NON_INTERACTIVE_STDIN=1
 fi
 
 while [[ $# -gt 0 ]]; do
@@ -290,8 +290,8 @@ if [[ -n "$PLAN_PATH" ]]; then
   fi
 
   if [[ "$status" != "APPROVED" && "$FORCE" != "1" ]]; then
-    if (( NON_TTY == 1 )); then
-      echo "Error: plan $plan_id is ${status:-PENDING} and code-implement is running without an interactive terminal." >&2
+    if (( NON_INTERACTIVE_STDIN == 1 )); then
+      echo "Error: plan $plan_id is ${status:-PENDING} and code-implement is running without interactive stdin." >&2
       echo "Resolve plan decisions before implementation or use --force explicitly." >&2
       echo "Examples:" >&2
       echo "  ./scripts/plan-review-live --plan \"$PLAN_PATH\" --decisions \"1A,2B,3A,4A\" --blocking none" >&2

--- a/scripts/plan-review-live-lobster
+++ b/scripts/plan-review-live-lobster
@@ -877,6 +877,8 @@ if [[ -n "$RESUME_TOKEN" ]]; then
     echo "[$LAST_PENDING_SECTION_NAME] Resume recovered pending checkpoint." >&2
     read_decision_input "$LAST_PENDING_SECTION_NAME" "selected" selected_input
     append_list_entries "$selected_input" "$RESOLVED_FILE"
+    # Persist selected decisions immediately so timeout on blocking input is resumable.
+    save_session_state "$RESUME_TOKEN" "$LAST_PENDING_SECTION_NAME" "$LAST_PENDING_RESUME_TOKEN"
     read_decision_input "$LAST_PENDING_SECTION_NAME" "blocking" blocking_input
     append_list_entries "$blocking_input" "$BLOCKING_FILE"
     save_session_state "$RESUME_TOKEN"
@@ -917,6 +919,8 @@ while true; do
 
     read_decision_input "$section_name" "selected" selected_input
     append_list_entries "$selected_input" "$RESOLVED_FILE"
+    # Persist selected decisions immediately so timeout on blocking input is resumable.
+    save_session_state "$token" "$section_name" "$token"
 
     read_decision_input "$section_name" "blocking" blocking_input
     append_list_entries "$blocking_input" "$BLOCKING_FILE"

--- a/scripts/smoke-wrappers.sh
+++ b/scripts/smoke-wrappers.sh
@@ -1098,6 +1098,55 @@ EOF
   assert_contains "$output" "reason=decision_input_timeout"
 }
 
+test_plan_review_live_lobster_timeout_on_blocking_keeps_selected_decisions() {
+  local repo="$tmp_dir/repo-plan-review-live-lobster-timeout-blocking"
+  local output_file="$repo/.ai/plan-reviews/live-output.md"
+  local lobster_state="$tmp_dir/lobster-state-timeout-blocking.txt"
+  local output="$tmp_dir/plan-review-live-lobster-timeout-blocking.out"
+  local session_state="${output_file}.lobster-session.json"
+  local fifo="$tmp_dir/plan-review-live-timeout-blocking.fifo"
+  mkdir -p "$repo/.ai/plans"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email smoke@example.com
+  git -C "$repo" config user.name smoke
+  echo "hi" > "$repo/README.md"
+  git -C "$repo" add README.md
+  git -C "$repo" commit -q -m "init"
+
+  cat > "$repo/.ai/plans/2026-02-19-000004e-live.md" <<'EOF'
+---
+id: 2026-02-19-000004e-live
+status: APPROVED
+---
+
+# Plan: Live Lobster Blocking Timeout Persistence
+EOF
+
+  mkfifo "$fifo"
+  exec 9<>"$fifo"
+  # Feed selected decisions once; keep fd open so blocking prompt times out.
+  printf '1A\n' >&9
+  set +e
+  PATH="$fake_bin:$PATH" \
+    PLAN_REVIEW_LIVE_ALLOW_NON_TTY=1 \
+    PLAN_REVIEW_LIVE_DECISION_TIMEOUT=1 \
+    SMOKE_LOBSTER_STATE_FILE="$lobster_state" \
+    "$SCRIPT_DIR/plan-review-live" --repo "$repo" --plan "$repo/.ai/plans/2026-02-19-000004e-live.md" --output "$output_file" > "$output" 2>&1 <&9
+  rc=$?
+  set -e
+  exec 9>&-
+  rm -f "$fifo"
+
+  if [[ "$rc" -eq 0 ]]; then
+    echo "Expected lobster live review to fail on blocking input timeout" >&2
+    exit 1
+  fi
+  [[ -f "$session_state" ]] || { echo "Expected session state to persist after blocking timeout" >&2; exit 1; }
+  assert_contains "$session_state" "\"resolved_decisions\": [\"1A\"]"
+  assert_contains "$session_state" "\"pending_section_name\": \"Architecture\""
+  assert_contains "$output" "reason=decision_input_timeout"
+}
+
 test_plan_review_live_generates_ready_metadata() {
   local repo="$tmp_dir/repo-plan-review-live"
   local codex_args="$tmp_dir/codex-plan-review-live-args.txt"
@@ -1529,7 +1578,7 @@ EOF
     exit 1
   fi
 
-  assert_contains "$output" "running without an interactive terminal"
+  assert_contains "$output" "running without interactive stdin"
   assert_contains "$output" "Resolve plan decisions before implementation or use --force explicitly."
   assert_not_contains "$output" "Do you approve this plan for execution?"
   assert_not_contains "$output" "Execution cancelled."
@@ -1779,6 +1828,7 @@ test_plan_review_live_lobster_default_engine
 test_plan_review_live_lobster_resume_preserves_decisions
 test_plan_review_live_lobster_resume_missing_state_auto_restarts
 test_plan_review_live_lobster_decision_timeout_fails_fast
+test_plan_review_live_lobster_timeout_on_blocking_keeps_selected_decisions
 test_plan_review_live_generates_ready_metadata
 test_plan_review_live_non_tty_auto_apply_with_flags
 test_plan_review_live_resolution_inputs_override_allow_non_tty


### PR DESCRIPTION
## What
- Adjusted `scripts/code-implement` pending-plan interactivity guard to rely on stdin only (`-t 0`) instead of stdin-or-stdout.
- Hardened `scripts/plan-review-live-lobster` timeout recovery by persisting selected decisions immediately before reading blocking decisions in both normal and resume-pending paths.
- Added regression smoke coverage in `scripts/smoke-wrappers.sh` for timeout on blocking prompt preserving selected decision state.

## Why
Follow-on review findings after #54 identified two regressions:
1. stdout redirection could incorrectly trigger non-interactive fail-fast in `code-implement`.
2. selected decisions could be lost if blocking-input prompt timed out.

These were reported in PR #54 comments and tracked in issue #55.

Closes #55.

## Tests
- `bash -n scripts/code-implement scripts/plan-review-live-lobster scripts/smoke-wrappers.sh`
- `./scripts/smoke-wrappers.sh`

## AI Assistance
- Used: yes (Codex CLI)
- Testing level: script syntax validation + wrapper smoke suite
- Prompt/session log: local Codex CLI session in this repository workspace
- I understand this code.
