### PR TITLE
fix(review-loop): auto-close linked issues

### DIFF
--- a/references/WORKFLOW.md
+++ b/references/WORKFLOW.md
@@ -198,6 +198,8 @@ Use this block in completion messages:
 - PR body sections (required): `What`, `Why`, `Tests`, `AI Assistance`.
 - `Tests`: list exact commands run.
 - `AI Assistance`: used/not used, testing level, prompt/session log link, and "I understand this code."
+- `review-loop-supervisor --open-pr --issue <n>` auto-injects `Closes #<n>`
+  into the PR body so GitHub can close the issue on merge.
 
 ## Agent Workflow
 

--- a/references/quick-reference.md
+++ b/references/quick-reference.md
@@ -178,6 +178,7 @@ claude --resume
 # Supervise review/fix loop until P0-P2 blockers clear
 ./scripts/review-loop-supervisor --repo /path/to/repo --base main
 # --open-pr expects a committed, clean feature branch before the review loop starts.
+# When --issue is set, the PR body automatically includes `Closes #<issue>`.
 ./scripts/review-loop-supervisor --repo /path/to/repo --base main \
   --test-cmd "npm run lint" --test-cmd "npm test" --open-pr --issue 50
 ```

--- a/scripts/review-loop-supervisor
+++ b/scripts/review-loop-supervisor
@@ -710,7 +710,7 @@ build_default_pr_body() {
 
   issue_block=""
   if [[ -n "$ISSUE_NUMBER" ]]; then
-    issue_block="Relates to #$ISSUE_NUMBER"
+    issue_block="Closes #$ISSUE_NUMBER"
   fi
 
   cat <<EOFPR
@@ -733,6 +733,27 @@ $tests_block
 
 $issue_block
 EOFPR
+}
+
+ensure_pr_body_issue_closure() {
+  local body="$1"
+  local issue_number="${2:-}"
+
+  if [[ -z "$issue_number" ]]; then
+    printf '%s' "$body"
+    return 0
+  fi
+
+  if printf '%s\n' "$body" | grep -Eq "(^|[^[:alnum:]])(Closes|Fixes|Resolves)[[:space:]]+#${issue_number}([^[:alnum:]]|$)"; then
+    printf '%s' "$body"
+    return 0
+  fi
+
+  if [[ -n "$body" ]]; then
+    printf '%s\n\nCloses #%s\n' "$body" "$issue_number"
+  else
+    printf 'Closes #%s\n' "$issue_number"
+  fi
 }
 
 sha256_cmd() {
@@ -1172,6 +1193,7 @@ open_or_update_pr() {
   else
     body="$(build_default_pr_body)"
   fi
+  body="$(ensure_pr_body_issue_closure "$body" "$ISSUE_NUMBER")"
 
   if [[ -n "$(repo_status_filtered)" ]]; then
     local commit_subject

--- a/scripts/smoke-wrappers.sh
+++ b/scripts/smoke-wrappers.sh
@@ -90,10 +90,37 @@ if [[ "${1:-}" == "pr" ]]; then
       exit 1
       ;;
     create)
+      body_file=""
+      prev=""
+      for arg in "$@"; do
+        if [[ "$prev" == "--body-file" ]]; then
+          body_file="$arg"
+          break
+        fi
+        prev="$arg"
+      done
+      if [[ -n "${SMOKE_GH_BODY_FILE:-}" && -n "$body_file" && -f "$body_file" ]]; then
+        cp "$body_file" "$SMOKE_GH_BODY_FILE"
+      fi
       printf '%s\n' "${SMOKE_GH_PR_CREATE_URL:-https://example.test/pr/123}"
       exit 0
       ;;
-    edit|checks)
+    edit)
+      body_file=""
+      prev=""
+      for arg in "$@"; do
+        if [[ "$prev" == "--body-file" ]]; then
+          body_file="$arg"
+          break
+        fi
+        prev="$arg"
+      done
+      if [[ -n "${SMOKE_GH_BODY_FILE:-}" && -n "$body_file" && -f "$body_file" ]]; then
+        cp "$body_file" "$SMOKE_GH_BODY_FILE"
+      fi
+      exit 0
+      ;;
+    checks)
       exit 0
       ;;
   esac
@@ -3280,6 +3307,7 @@ test_review_loop_supervisor_open_pr_creates_pr() {
   local output="$tmp_dir/review-loop-open-pr.out"
   local codex_args="$tmp_dir/review-loop-open-pr-codex-args.txt"
   local gh_args="$tmp_dir/review-loop-open-pr-gh-args.txt"
+  local gh_body="$tmp_dir/review-loop-open-pr-gh-body.md"
   local state_file="$tmp_dir/review-loop-open-pr-state.txt"
 
   mkdir -p "$repo"
@@ -3295,6 +3323,7 @@ test_review_loop_supervisor_open_pr_creates_pr() {
     SMOKE_REVIEW_LOOP_STATE_FILE="$state_file" \
     SMOKE_CODEX_ARGS_FILE="$codex_args" \
     SMOKE_GH_ARGS_FILE="$gh_args" \
+    SMOKE_GH_BODY_FILE="$gh_body" \
     SMOKE_GH_PR_EXISTS=0 \
     SMOKE_GH_PR_CREATE_URL="https://example.test/pr/321" \
     "$SCRIPT_DIR/review-loop-supervisor" --repo "$repo" --base main --open-pr --issue 50 >"$output" 2>&1; then
@@ -3308,6 +3337,7 @@ test_review_loop_supervisor_open_pr_creates_pr() {
   assert_contains "$output" "PR: https://example.test/pr/321"
   assert_contains "$gh_args" "pr"
   assert_contains "$gh_args" "create"
+  assert_contains "$gh_body" "Closes #50"
   assert_contains "$repo/.ai/review-loops/latest.json" "\"pr_url\": \"https://example.test/pr/321\""
 }
 
@@ -3317,6 +3347,7 @@ test_review_loop_supervisor_open_pr_updates_existing_pr() {
   local output="$tmp_dir/review-loop-open-pr-update.out"
   local codex_args="$tmp_dir/review-loop-open-pr-update-codex-args.txt"
   local gh_args="$tmp_dir/review-loop-open-pr-update-gh-args.txt"
+  local gh_body="$tmp_dir/review-loop-open-pr-update-gh-body.md"
   local state_file="$tmp_dir/review-loop-open-pr-update-state.txt"
 
   mkdir -p "$repo"
@@ -3333,6 +3364,7 @@ test_review_loop_supervisor_open_pr_updates_existing_pr() {
     SMOKE_REVIEW_LOOP_STATE_FILE="$state_file" \
     SMOKE_CODEX_ARGS_FILE="$codex_args" \
     SMOKE_GH_ARGS_FILE="$gh_args" \
+    SMOKE_GH_BODY_FILE="$gh_body" \
     SMOKE_GH_PR_EXISTS=1 \
     "$SCRIPT_DIR/review-loop-supervisor" --repo "$repo" --base main --open-pr --issue 50 >"$output" 2>&1; then
     cat "$output" >&2
@@ -3345,6 +3377,7 @@ test_review_loop_supervisor_open_pr_updates_existing_pr() {
   assert_contains "$gh_args" "edit"
   assert_contains "$gh_args" "--repo"
   assert_contains "$gh_args" "example/repo.name"
+  assert_contains "$gh_body" "Closes #50"
   assert_contains "$repo/.ai/review-loops/latest.json" "\"pr_url\": \"https://example.test/pr/99\""
 }
 


### PR DESCRIPTION
## What
- Add issue-closing keyword injection to `review-loop-supervisor` when `--issue` is provided.
- Switch the default review-loop PR body from `Relates to #N` to `Closes #N`.
- Add smoke coverage that captures the PR body handed to `gh pr create` and `gh pr edit`.
- Document the new behavior in the shared workflow references.

## Why
- PRs that resolve issues should close them automatically on merge.
- Centralizing the rule in the shared review loop prevents repeated manual fixes across repos and sessions.

## Tests
- `bash /tmp/test-pr-hook.sh`

## AI Assistance
- Used: yes
- Testing level: direct integration harness plus repo smoke-harness updates
- Prompt/session log: current Codex session in this terminal
- I understand this code.
