### PR TITLE
docs: clarify worktree execution flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ CLI wrappers:
 # Requires latest plan-review metadata to be ready unless --force is used.
 # In non-TTY orchestration, this fails fast if plan status is not APPROVED.
 # If the next step is review-loop-supervisor --open-pr, commit the generated implementation changes first.
+# When executing from Hermes, do the work in a dedicated git worktree, not in the primary checkout.
+# Phase B stops after push + PR; do not merge or deploy from this flow.
 # Wrapper output remains text by default; pass --output json explicitly for machine-readable automation.
 ./scripts/code-implement --plan /path/to/repo/.ai/plans/<plan>.md
 


### PR DESCRIPTION
## Summary
- Clarify that Hermes execution should happen in a dedicated git worktree, not the primary checkout.
- Reinforce that Phase B stops after push + PR and does not merge or deploy.

## Testing
- Not run: documentation-only change.
- Verified by reviewing the final README diff.

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required: this change only updates repository documentation and does not affect runtime behavior.

## Before / After Screenshots
- Not applicable.

## Notes
- Kept the change intentionally small and scoped to README.md.
